### PR TITLE
Add in CA plumbing for custom certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Please see the examples directory for more extensive examples.
 | tls\_pfx\_certificate\_password | The password for the associated SSL certificate. | string | n/a | yes |
 | virtual\_network\_name | An existing Azure Virtual Network to deploy into | string | n/a | yes |
 | resource\_prefix | Prefix name for resources created by this module | string| tfe | no |
+| ca_cert_url | URL to CA certificate file used for the internal `ptfe-proxy` used for outgoing connections| string | `"none"` | no |
 | airgap\_installer\_url | URL to replicated's airgap installer package | string | `"https://install.terraform.io/installer/replicated-v5.tar.gz"` | no |
 | airgap\_mode\_enable | install in airgap mode | string | `"False"` | no |
 | airgap\_package\_url | Signed URL to download the package | string | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -55,6 +55,7 @@ module "configs" {
   http_proxy_url       = "${var.http_proxy_url}"
   installer_url        = "${var.installer_url}"
   import_key           = "${var.import_key}"
+  ca_cert_url          = "${var.ca_cert_url}"
 
   iact = {
     subnet_list       = "${var.iact_subnet_list}"

--- a/modules/configs/README.md
+++ b/modules/configs/README.md
@@ -19,6 +19,7 @@
 | license\_file | Path to license file for the application | string | n/a | yes |
 | postgresql | Expects keys: [user, password, address, database, extra_params] | map | n/a | yes |
 | primary\_count | The count of primary instances being created. | string | n/a | yes |
+| ca_cert_url | URL to CA certificate file used for the internal `ptfe-proxy` used for outgoing connections| string | `"none"` | no |
 
 ## Outputs
 

--- a/modules/configs/cloud-init.tf
+++ b/modules/configs/cloud-init.tf
@@ -76,6 +76,7 @@ data "template_file" "cloud_config" {
     primary_pki_url      = "http://${var.cluster_api_endpoint}:${var.assistant_port}/api/v1/pki-download?token=${random_string.setup_token.result}"
     health_url           = "http://${var.cluster_api_endpoint}:${var.assistant_port}/healthz"
     cert_thumbprint      = "${var.cert_thumbprint}"
+    ca_cert_url          = "${var.ca_cert_url}"
   }
 }
 

--- a/modules/configs/cloud-init.tf
+++ b/modules/configs/cloud-init.tf
@@ -106,6 +106,7 @@ data "template_file" "cloud_config_secondary" {
     distro               = "${var.distribution}"
     aaa_proxy_b64        = "${base64encode(data.template_file.aaa_proxy_b64.rendered)}"
     proxy_b64            = "${base64encode(data.template_file.proxy_sh.rendered)}"
+    ca_cert_url          = "${var.ca_cert_url}"
   }
 }
 

--- a/modules/configs/files/install-ptfe.sh
+++ b/modules/configs/files/install-ptfe.sh
@@ -62,6 +62,57 @@ public_ip=$(curl -H Metadata:true "http://169.254.169.254/metadata/instance/netw
 airgap_url_path="/etc/ptfe/airgap-package-url"
 airgap_installer_url_path="/etc/ptfe/airgap-installer-url"
 
+# ------------------------------------------------------------------------------
+# Custom CA certificate download and configuration block
+# ------------------------------------------------------------------------------
+if [[ -n $(< /etc/ptfe/custom-ca-cert-url) && \
+      $(< /etc/ptfe/custom-ca-cert-url) != none ]]; then
+  custom_ca_cert_url=$(cat /etc/ptfe/custom-ca-cert-url)
+  custom_ca_cert_file_name=$(echo "${custom_ca_cert_url}" | awk -F '/' '{ print $NF }')
+  ca_tmp_dir="/tmp/ptfe/customer-certs"
+  replicated_conf_file="replicated-ptfe.conf"
+  local_messages_file="local_messages.log"
+  # Setting up a tmp directory to do this `jq` transform to leave artifacts if anything goes "boom",
+  # since we're trusting user input to be both a working URL and a valid certificate.
+  # These artifacts will live in /tmp/ptfe/customer-certs/{local_messages.log,wget_output.log} files.
+  mkdir -p "${ca_tmp_dir}"
+  pushd "${ca_tmp_dir}"
+  touch ${local_messages_file}
+  if wget --trust-server-files "${custom_ca_cert_url}" >> ./wget_output.log 2>&1;
+  then
+    if [ -f "${ca_tmp_dir}/${custom_ca_cert_file_name}" ];
+    then
+      if openssl x509 -in "${custom_ca_cert_file_name}" -text -noout;
+      then
+        mv "${custom_ca_cert_file_name}" cust-ca-certificates.crt
+        cp /etc/${replicated_conf_file} ./${replicated_conf_file}.original
+        jq ". + { ca_certs: { value: \"$(cat cust-ca-certificates.crt)\" } }" -- ${replicated_conf_file}.original > ${replicated_conf_file}.updated
+        if jq -e . > /dev/null 2>&1 -- ${replicated_conf_file}.updated;
+        then
+          cp ./${replicated_conf_file}.updated /etc/${replicated_conf_file}
+        else
+          echo "The updated ${replicated_conf_file} file is not valid JSON." | tee -a "${local_messages_file}"
+          echo "Review ${ca_tmp_dir}/${replicated_conf_file}.original and ${ca_tmp_dir}/${replicated_conf_file}.updated." | tee -a "${local_messages_file}"
+          echo "" | tee -a "${local_messages_file}"
+        fi
+      else
+        echo "The certificate file wasn't able to validated via openssl" | tee -a "${local_messages_file}"
+        echo "" | tee -a "${local_messages_file}"
+      fi
+    else
+      echo "The filename ${custom_ca_cert_file_name} was not what ${custom_ca_cert_url} downloaded." | tee -a "${local_messages_file}"
+      echo "Inspect the ${ca_tmp_dir} directory to verify the file that was downloaded." | tee -a "${local_messages_file}"
+      echo "" | tee -a "${local_messages_file}"
+    fi
+  else
+    echo "There was an error downloading the file ${custom_ca_cert_file_name} from ${custom_ca_cert_url}." | tee -a "${local_messages_file}"
+    echo "See the ${ca_tmp_dir}/wget_output.log file." | tee -a "${local_messages_file}"
+    echo "" | tee -a "${local_messages_file}"
+  fi
+
+  popd
+fi
+
 ptfe_install_args=(
     -DD
     "--bootstrap-token=$(cat /etc/ptfe/bootstrap-token)" \

--- a/modules/configs/templates/cloud-init/cloud-config.yaml
+++ b/modules/configs/templates/cloud-init/cloud-config.yaml
@@ -68,7 +68,7 @@ write_files:
   permissions: "0755"
   encoding: b64
   content: ${proxy_b64}
-    
+
 %{~ endif ~}
 
 %{~ if role == "main" ~}
@@ -116,7 +116,7 @@ write_files:
   permissions: "0400"
   encoding: b64
   content: ${aaa_proxy_b64}
-    
+
 %{ endif ~}
 
 %{ if distro == "ubuntu" ~}

--- a/modules/configs/templates/cloud-init/cloud-config.yaml
+++ b/modules/configs/templates/cloud-init/cloud-config.yaml
@@ -42,6 +42,11 @@ write_files:
   permissions: "0400"
   content: "${proxy_url}"
 
+- path: /etc/ptfe/custom-ca-cert-url
+  owner: root:root
+  permissions: "0400"
+  content: "${ca_cert_url}"
+
 %{~ if role != "secondary" ~}
 - path: /etc/ptfe/setup-token
   owner: root:root

--- a/modules/configs/templates/replicated/replicated-ptfe.conf
+++ b/modules/configs/templates/replicated/replicated-ptfe.conf
@@ -39,7 +39,7 @@
     },
     "azure_container": {
         "value": "${azure_container}"
-    
+
 %{ endif }
     },
     "iact_subnet_list": {

--- a/modules/configs/variables.tf
+++ b/modules/configs/variables.tf
@@ -75,6 +75,12 @@ variable "airgap" {
 
 # === Optional
 
+variable "ca_cert_url" {
+  type        = "string"
+  description = "URL to CA certificate file used for the internal `ptfe-proxy` used for outgoing connections"
+  default     = "none"
+}
+
 # === Misc
 
 locals {

--- a/modules/configs/variables.tf
+++ b/modules/configs/variables.tf
@@ -15,7 +15,7 @@ variable cluster_endpoint {
 }
 
 variable "cluster_api_endpoint" {
-   type        = "string"
+  type        = "string"
   description = "URI to the cluster api"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -66,6 +66,12 @@ variable "airgap_package_url" {
   default     = ""
 }
 
+variable "ca_cert_url" {
+  type        = "string"
+  description = "URL to CA certificate file used for the internal `ptfe-proxy` used for outgoing connections"
+  default     = "none"
+}
+
 variable "azure_es_account_key" {
   type        = "string"
   description = "The Azure account key for external services"


### PR DESCRIPTION
This is work that was done originally in hashicorp/terraform-google-terraform-enterprise#3 and ported over to this repo. The largest difference between these two implementations is that this TF uses cloud-config and the other didn't. But everything else is pretty much the same.