### PR TITLE
Fix modules/common parameter rendering

### DIFF
--- a/modules/common/variables.tf
+++ b/modules/common/variables.tf
@@ -50,6 +50,6 @@ locals {
   public_key_filename     = "${local.ssh_public_key_path}/${local.key_name}.pub"
   private_key_filename    = "${local.ssh_public_key_path}/${local.key_name}.priv"
   prefix                  = "${var.resource_prefix}-${var.install_id}"
-  rendered_kv_rg_name     = "${coalesce(var.key_vault["name"], var.rg_name)}"
+  rendered_kv_rg_name     = "${coalesce(var.key_vault["rg_name"], var.rg_name)}"
   rendered_domain_rg_name = "${coalesce(var.dns["rg_name"], var.rg_name)}"
 }


### PR DESCRIPTION
## Background

This PR fixes a bug in the module where the key_vault data source will not build correctly unless the key vault is named with the same name as the resource group the key vault lives in. 

Thanks goes out to our Support Engineering team for finding this!

## This PR makes me feel
![officeworkers jump highfiving with rainbow glitter TEAMWORK sparkling in the foreground](https://media.giphy.com/media/dSetNZo2AJfptAk9hp/giphy.gif)