### PR TITLE
fixed issue #11

### DIFF
--- a/modules/configs/templates/replicated/replicated-ptfe.conf
+++ b/modules/configs/templates/replicated/replicated-ptfe.conf
@@ -31,6 +31,9 @@
     "pg_extra_params": {
         "value": "${pg_extra_params}"
     },
+    "placement": {
+        "value": "placement_azure"
+    },
     "azure_account_name": {
         "value": "${azure_account_name}"
     },


### PR DESCRIPTION
replicated-ptfe.conf was missing a line to set the "placement" attribute which tells replicated which type of storage to use. Without this, it defaults always to aws.