### PR TITLE
Primaries and IPM

### DIFF
--- a/modules/primaries/vms.tf
+++ b/modules/primaries/vms.tf
@@ -1,5 +1,5 @@
 resource "azurerm_virtual_machine" "primary" {
-  count                        = "${var.vm["count"]}"
+  count                        = "${var.install_type == "ipm" ? 3 : var.vm["count"]}"
   name                         = "${local.prefix}-${count.index}"
   resource_group_name          = "${var.rg_name}"
   location                     = "${var.location}"

--- a/variables.tf
+++ b/variables.tf
@@ -187,7 +187,7 @@ variable "postgresql_user" {
 }
 
 variable "primary_count" {
-  description = "The number of primary virtual machines to create."
+  description = "The number of primary virtual machines to create, should be set to 3 or 5."
   default     = 3
 }
 


### PR DESCRIPTION
When internal production mode is set, the number of primaries needs to be hard set at 3, due to scaling issues with ceph. Otherwise, the value of the count variable will be used.