### PR TITLE
Custom Weave & Repl Service CIDR bits

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,13 @@ Please see the examples directory for more extensive examples.
 | postgresql\_user | user to connect to external postgresql database as | string | `""` | no |
 | primary\_count | The number of primary virtual machines to create. | string | `"3"` | no |
 | primary\_vm\_size | The Azure VM Size to use. | string | `"Standard_D4s_v3"` | no |
+| repl\_cidr | Specify a non-standard CIDR range for the replicated services. The default is `10.96.0.0/12` | string | `""` | no |
 | secondary\_count | The number of secondary virtual machines to create. | string | `"5"` | no |
 | secondary\_vm\_size | The Azure VM Size to use (will use primary_vm_size if not set). | string | `""` | no |
 | ssh\_user | The ssh user to create | string | `"ubuntu"` | no |
 | storage\_image | A list of the data to define the os version image to build from | map | `{ "offer": "UbuntuServer", "publisher": "Canonical", "sku": "18.04-LTS", "version": "latest" }` | no |
 | vm\_size\_tier | The tier for the vms (must be 'Standard' or 'Basic') and must match with vm_size | string | `"Standard"` | no |
+| weave\_cidr | Specify a non-standard CIDR range for weave. The default is `172.18.0.0/16` | string | `""` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -56,6 +56,8 @@ module "configs" {
   installer_url        = "${var.installer_url}"
   import_key           = "${var.import_key}"
   ca_cert_url          = "${var.ca_cert_url}"
+  weave_cidr           = "${var.weave_cidr}"
+  repl_cidr            = "${var.repl_cidr}"
 
   iact = {
     subnet_list       = "${var.iact_subnet_list}"

--- a/modules/configs/cloud-init.tf
+++ b/modules/configs/cloud-init.tf
@@ -77,6 +77,8 @@ data "template_file" "cloud_config" {
     health_url           = "http://${var.cluster_api_endpoint}:${var.assistant_port}/healthz"
     cert_thumbprint      = "${var.cert_thumbprint}"
     ca_cert_url          = "${var.ca_cert_url}"
+    weave_cidr           = "${var.weave_cidr}"
+    repl_cidr            = "${var.repl_cidr}"
   }
 }
 

--- a/modules/configs/files/install-ptfe.sh
+++ b/modules/configs/files/install-ptfe.sh
@@ -61,6 +61,8 @@ public_ip=$(curl -H Metadata:true "http://169.254.169.254/metadata/instance/netw
 
 airgap_url_path="/etc/ptfe/airgap-package-url"
 airgap_installer_url_path="/etc/ptfe/airgap-installer-url"
+weave_cidr="/etc/ptfe/weave_cidr"
+repl_cidr="/etc/ptfe/repl_cidr"
 
 # ------------------------------------------------------------------------------
 # Custom CA certificate download and configuration block
@@ -146,6 +148,18 @@ if [ "x${role}x" == "xmainx" ]; then
         ptfe_install_args+=(
             --airgap-installer /var/lib/ptfe/replicated.tar.gz
         )
+    fi
+
+    if test -e "$weave_cidr"; then
+      ptfe_install_args+=(
+          "--weaveCIDR=$(cat /etc/ptfe/weave_cidr)"
+      )
+    fi
+
+    if test -e "$repl_cidr"; then
+      ptfe_install_args+=(
+          "--replCIDR=$(cat /etc/ptfe/repl_cidr)"
+      )
     fi
 fi
 

--- a/modules/configs/templates/cloud-init/cloud-config.yaml
+++ b/modules/configs/templates/cloud-init/cloud-config.yaml
@@ -108,6 +108,20 @@ write_files:
   permissions: "0644"
   content: ${airgap_installer_url}
 %{ endif ~}
+
+%{ if weave_cidr != "" }
+- path: /etc/ptfe/weave-cidr
+  owner: root:root
+  permissions: "0644"
+  content: ${weave_cidr}
+%{ endif }
+
+%{ if repl_cidr != "" }
+- path: /etc/ptfe/repl-cidr
+  owner: root:root
+  permissions: "0644"
+  content: ${repl_cidr}
+%{ endif }
 %{ endif ~}
 
 %{ if role == "secondary" ~}

--- a/modules/configs/variables.tf
+++ b/modules/configs/variables.tf
@@ -73,6 +73,16 @@ variable "airgap" {
   description = "Expects keys: [enable, package_url, installer_url]"
 }
 
+variable "weave_cidr" {
+  type        = "string"
+  description = "custom weave CIDR range"
+}
+
+variable "repl_cidr" {
+  type        = "string"
+  description = "custom replicated service CIDR range"
+}
+
 # === Optional
 
 variable "ca_cert_url" {

--- a/variables.tf
+++ b/variables.tf
@@ -238,6 +238,18 @@ variable "vm_size_tier" {
   default     = "Standard"
 }
 
+variable "weave_cidr" {
+  type        = "string"
+  description = "Specify a non-standard CIDR range for weave. The default is 172.18.0.0/16"
+  default     = ""
+}
+
+variable "repl_cidr" {
+  type        = "string"
+  description = "Specify a non-standard CIDR range for the replicated services. The default is 10.96.0.0/12"
+  default     = ""
+}
+
 # ============================================================ MISC
 
 locals {


### PR DESCRIPTION
This allows a module user to specify a custom CIDR range for weave to use or the replicated service. It was discovered many moons ago that if the default CIDR range is already in use, you can break k8s in new and fun ways. Changes to the ptfe installer previously made, this change exposes this feature in the module to end users.