### PR TITLE
Fix intall script

### DIFF
--- a/modules/configs/files/install-ptfe.sh
+++ b/modules/configs/files/install-ptfe.sh
@@ -22,8 +22,9 @@ if [ -f /etc/redhat-release ]; then
   mkdir -p /lib/tc
   mount --bind /usr/lib64/tc/ /lib/tc/
   sed -i -e 's/^SELINUX=enforcing/SELINUX=permissive/' /etc/sysconfig/selinux
-  sed -i -e '/rhui-REGION-rhel-server-extras/,/^$/s/enabled=0/enabled=1/g'  /etc/yum.repos.d/redhat-rhui.repo
-  yum -y install docker wget jq chrony ipvsadm unzip
+  yum -y install docker wget chrony ipvsadm unzip
+  curl -sfSL -o /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+  chmod +x /usr/bin/jq
   systemctl enable docker
   systemctl start docker
 else


### PR DESCRIPTION
Fixed install script to no longer attempt to enable the extras repo (it's enabled by default on Azure) and corrected the jq install to pull the binary from github, as it's not in any of the repos.