### PR TITLE
Update Custom Weave/Replicated CIDR variables for new ptfe flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Please see the examples directory for more extensive examples.
 | ssh\_user | The ssh user to create | string | `"ubuntu"` | no |
 | storage\_image | A list of the data to define the os version image to build from | map | `{ "offer": "UbuntuServer", "publisher": "Canonical", "sku": "18.04-LTS", "version": "latest" }` | no |
 | vm\_size\_tier | The tier for the vms (must be 'Standard' or 'Basic') and must match with vm_size | string | `"Standard"` | no |
-| weave\_cidr | Specify a non-standard CIDR range for weave. The default is `172.18.0.0/16` | string | `""` | no |
+| weave\_cidr | Specify a non-standard CIDR range for weave. The default is `10.32.0.0/12` | string | `""` | no |
 
 ## Outputs
 

--- a/modules/configs/files/install-ptfe.sh
+++ b/modules/configs/files/install-ptfe.sh
@@ -64,8 +64,8 @@ public_ip=$(curl -H Metadata:true "http://169.254.169.254/metadata/instance/netw
 
 airgap_url_path="/etc/ptfe/airgap-package-url"
 airgap_installer_url_path="/etc/ptfe/airgap-installer-url"
-weave_cidr="/etc/ptfe/weave_cidr"
-repl_cidr="/etc/ptfe/repl_cidr"
+weave_cidr="/etc/ptfe/weave-cidr"
+repl_cidr="/etc/ptfe/repl-cidr"
 
 # ------------------------------------------------------------------------------
 # Custom CA certificate download and configuration block
@@ -155,13 +155,13 @@ if [ "x${role}x" == "xmainx" ]; then
 
     if test -e "$weave_cidr"; then
       ptfe_install_args+=(
-          "--weaveCIDR=$(cat /etc/ptfe/weave_cidr)"
+          "--ip-alloc-range=$(cat /etc/ptfe/weave-cidr)"
       )
     fi
 
     if test -e "$repl_cidr"; then
       ptfe_install_args+=(
-          "--replCIDR=$(cat /etc/ptfe/repl_cidr)"
+          "--service-cidr=$(cat /etc/ptfe/repl-cidr)"
       )
     fi
 fi

--- a/variables.tf
+++ b/variables.tf
@@ -240,7 +240,7 @@ variable "vm_size_tier" {
 
 variable "weave_cidr" {
   type        = "string"
-  description = "Specify a non-standard CIDR range for weave. The default is 172.18.0.0/16"
+  description = "Specify a non-standard CIDR range for weave. The default is 10.32.0.0/12"
   default     = ""
 }
 


### PR DESCRIPTION
Much like https://github.com/hashicorp/terraform-aws-terraform-enterprise/pull/13 and https://github.com/hashicorp/terraform-google-terraform-enterprise/pull/13 but for Azure! 🎉 

From  https://github.com/hashicorp/terraform-aws-terraform-enterprise/pull/13 : 
> As we upgraded to Replicated 2.39.0 in the `ptfe` tool we ran into an issue where there was a conflict with the default we introduced before we could customize the CIDR that Weave uses. Now that this feature exists we don't need the patched in default but it turns out that the installer wasn't using the correct flags for the `ptfe` tool to pass the ip allocation (`--weaveCIDR` vs `--ip-alloc-range` and `--replCIDR` vs `--service-cidr`, the latter being the correct ones). Similarly the filenames shifted a bit so it was often checking for a file that didn't exist. Likely a case where the ptfe tool updated the flags but got missed in the installers.
> 
> Finally, since we removed the default CIDR in the Replicated installer I updated comment/docs to show the Replicated default for Weave. 🎉

