### PR TITLE
roll back default ubuntu version to xenial

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -227,7 +227,7 @@ variable "storage_image" {
   default = {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "18.04-LTS"
+    sku       = "16.04-LTS"
     version   = "latest"
   }
 }


### PR DESCRIPTION
# Background
This is regarding Issue https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/issues/21

set default os image to one that actually works with our clustering versions while we look at Bionic fixes.

## This PR makes me feel
![clamping style hex wrench tightening bolt on a blue bike's wheel](http://giphygifs.s3.amazonaws.com/media/5qyhm3osMWMJG/giphy.gif)