### PR TITLE
Fix Custom CA bundle install, rename ca_cert_url to ca_bundle_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ Please see the examples directory for more extensive examples.
 | tls\_pfx\_certificate\_password | The password for the associated SSL certificate. | string | n/a | yes |
 | virtual\_network\_name | An existing Azure Virtual Network to deploy into | string | n/a | yes |
 | resource\_prefix | Prefix name for resources created by this module | string| tfe | no |
-| ca_cert_url | URL to CA certificate file used for the internal `ptfe-proxy` used for outgoing connections| string | `"none"` | no |
 | airgap\_installer\_url | URL to replicated's airgap installer package | string | `"https://install.terraform.io/installer/replicated-v5.tar.gz"` | no |
 | airgap\_mode\_enable | install in airgap mode | string | `"False"` | no |
 | airgap\_package\_url | Signed URL to download the package | string | `""` | no |
 | azure\_es\_account\_key | The Azure account key for external services | string | `""` | no |
 | azure\_es\_account\_name | The Azure account name for external services | string | `""` | no |
 | azure\_es\_container | The Azure container for external services | string | `""` | no |
+| ca_bundle_url | URL to Custom CA bundle used for outgoing connections | string | `"none"` | no |
 | distribution | Type of linux distribution to use. (ubuntu or rhel) | string | `"ubuntu"` | no |
 | dns\_ttl | The TTL for dns records. | string | `"120"` | no |
 | domain\_resource\_group\_name | The name of the resource group where the domain name resides, if not set the main resource group will be used. | string | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ module "configs" {
   http_proxy_url       = "${var.http_proxy_url}"
   installer_url        = "${var.installer_url}"
   import_key           = "${var.import_key}"
-  ca_bundle_url          = "${var.ca_bundle_url}"
+  ca_bundle_url        = "${var.ca_bundle_url}"
   weave_cidr           = "${var.weave_cidr}"
   repl_cidr            = "${var.repl_cidr}"
 

--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ module "configs" {
   http_proxy_url       = "${var.http_proxy_url}"
   installer_url        = "${var.installer_url}"
   import_key           = "${var.import_key}"
-  ca_cert_url          = "${var.ca_cert_url}"
+  ca_bundle_url          = "${var.ca_bundle_url}"
   weave_cidr           = "${var.weave_cidr}"
   repl_cidr            = "${var.repl_cidr}"
 

--- a/modules/configs/README.md
+++ b/modules/configs/README.md
@@ -19,7 +19,7 @@
 | license\_file | Path to license file for the application | string | n/a | yes |
 | postgresql | Expects keys: [user, password, address, database, extra_params] | map | n/a | yes |
 | primary\_count | The count of primary instances being created. | string | n/a | yes |
-| ca_cert_url | URL to CA certificate file used for the internal `ptfe-proxy` used for outgoing connections| string | `"none"` | no |
+| ca_bundle_url | URL to CA certificate file used for the internal `ptfe-proxy` used for outgoing connections| string | `"none"` | no |
 
 ## Outputs
 

--- a/modules/configs/cloud-init.tf
+++ b/modules/configs/cloud-init.tf
@@ -76,7 +76,7 @@ data "template_file" "cloud_config" {
     primary_pki_url      = "http://${var.cluster_api_endpoint}:${var.assistant_port}/api/v1/pki-download?token=${random_string.setup_token.result}"
     health_url           = "http://${var.cluster_api_endpoint}:${var.assistant_port}/healthz"
     cert_thumbprint      = "${var.cert_thumbprint}"
-    ca_bundle_url          = "${var.ca_bundle_url}"
+    ca_bundle_url        = "${var.ca_bundle_url}"
     weave_cidr           = "${var.weave_cidr}"
     repl_cidr            = "${var.repl_cidr}"
   }
@@ -108,7 +108,7 @@ data "template_file" "cloud_config_secondary" {
     distro               = "${var.distribution}"
     aaa_proxy_b64        = "${base64encode(data.template_file.aaa_proxy_b64.rendered)}"
     proxy_b64            = "${base64encode(data.template_file.proxy_sh.rendered)}"
-    ca_bundle_url          = "${var.ca_bundle_url}"
+    ca_bundle_url        = "${var.ca_bundle_url}"
   }
 }
 

--- a/modules/configs/cloud-init.tf
+++ b/modules/configs/cloud-init.tf
@@ -76,7 +76,7 @@ data "template_file" "cloud_config" {
     primary_pki_url      = "http://${var.cluster_api_endpoint}:${var.assistant_port}/api/v1/pki-download?token=${random_string.setup_token.result}"
     health_url           = "http://${var.cluster_api_endpoint}:${var.assistant_port}/healthz"
     cert_thumbprint      = "${var.cert_thumbprint}"
-    ca_cert_url          = "${var.ca_cert_url}"
+    ca_bundle_url          = "${var.ca_bundle_url}"
     weave_cidr           = "${var.weave_cidr}"
     repl_cidr            = "${var.repl_cidr}"
   }
@@ -108,7 +108,7 @@ data "template_file" "cloud_config_secondary" {
     distro               = "${var.distribution}"
     aaa_proxy_b64        = "${base64encode(data.template_file.aaa_proxy_b64.rendered)}"
     proxy_b64            = "${base64encode(data.template_file.proxy_sh.rendered)}"
-    ca_cert_url          = "${var.ca_cert_url}"
+    ca_bundle_url          = "${var.ca_bundle_url}"
   }
 }
 

--- a/modules/configs/files/install-ptfe.sh
+++ b/modules/configs/files/install-ptfe.sh
@@ -74,16 +74,16 @@ if [[ -n $(< /etc/ptfe/custom-ca-cert-url) && \
       $(< /etc/ptfe/custom-ca-cert-url) != none ]]; then
   custom_ca_bundle_url=$(cat /etc/ptfe/custom-ca-cert-url)
   custom_ca_cert_file_name=$(echo "${custom_ca_bundle_url}" | awk -F '/' '{ print $NF }')
-  ca_tmp_dir="/tmp/ptfe/customer-certs"
+  ca_tmp_dir="/tmp/ptfe-customer-certs"
   replicated_conf_file="replicated-ptfe.conf"
   local_messages_file="local_messages.log"
-  # Setting up a tmp directory to do this `jq` transform to leave artifacts if anything goes "boom",
+  # Setting up a tmp directory to do this `jq` transform to leave artifacts if anything goes "boom".
   # since we're trusting user input to be both a working URL and a valid certificate.
-  # These artifacts will live in /tmp/ptfe/customer-certs/{local_messages.log,wget_output.log} files.
+  # These artifacts will live in /tmp/ptfe-customer-certs/{local_messages.log,wget_output.log} files.
   mkdir -p "${ca_tmp_dir}"
   pushd "${ca_tmp_dir}"
   touch ${local_messages_file}
-  if wget --trust-server-files "${custom_ca_bundle_url}" >> ./wget_output.log 2>&1;
+  if wget --trust-server-names "${custom_ca_bundle_url}" >> ./wget_output.log 2>&1;
   then
     if [ -f "${ca_tmp_dir}/${custom_ca_cert_file_name}" ];
     then

--- a/modules/configs/files/install-ptfe.sh
+++ b/modules/configs/files/install-ptfe.sh
@@ -72,8 +72,8 @@ repl_cidr="/etc/ptfe/repl-cidr"
 # ------------------------------------------------------------------------------
 if [[ -n $(< /etc/ptfe/custom-ca-cert-url) && \
       $(< /etc/ptfe/custom-ca-cert-url) != none ]]; then
-  custom_ca_cert_url=$(cat /etc/ptfe/custom-ca-cert-url)
-  custom_ca_cert_file_name=$(echo "${custom_ca_cert_url}" | awk -F '/' '{ print $NF }')
+  custom_ca_bundle_url=$(cat /etc/ptfe/custom-ca-cert-url)
+  custom_ca_cert_file_name=$(echo "${custom_ca_bundle_url}" | awk -F '/' '{ print $NF }')
   ca_tmp_dir="/tmp/ptfe/customer-certs"
   replicated_conf_file="replicated-ptfe.conf"
   local_messages_file="local_messages.log"
@@ -83,7 +83,7 @@ if [[ -n $(< /etc/ptfe/custom-ca-cert-url) && \
   mkdir -p "${ca_tmp_dir}"
   pushd "${ca_tmp_dir}"
   touch ${local_messages_file}
-  if wget --trust-server-files "${custom_ca_cert_url}" >> ./wget_output.log 2>&1;
+  if wget --trust-server-files "${custom_ca_bundle_url}" >> ./wget_output.log 2>&1;
   then
     if [ -f "${ca_tmp_dir}/${custom_ca_cert_file_name}" ];
     then
@@ -105,12 +105,12 @@ if [[ -n $(< /etc/ptfe/custom-ca-cert-url) && \
         echo "" | tee -a "${local_messages_file}"
       fi
     else
-      echo "The filename ${custom_ca_cert_file_name} was not what ${custom_ca_cert_url} downloaded." | tee -a "${local_messages_file}"
+      echo "The filename ${custom_ca_cert_file_name} was not what ${custom_ca_bundle_url} downloaded." | tee -a "${local_messages_file}"
       echo "Inspect the ${ca_tmp_dir} directory to verify the file that was downloaded." | tee -a "${local_messages_file}"
       echo "" | tee -a "${local_messages_file}"
     fi
   else
-    echo "There was an error downloading the file ${custom_ca_cert_file_name} from ${custom_ca_cert_url}." | tee -a "${local_messages_file}"
+    echo "There was an error downloading the file ${custom_ca_cert_file_name} from ${custom_ca_bundle_url}." | tee -a "${local_messages_file}"
     echo "See the ${ca_tmp_dir}/wget_output.log file." | tee -a "${local_messages_file}"
     echo "" | tee -a "${local_messages_file}"
   fi

--- a/modules/configs/templates/cloud-init/cloud-config.yaml
+++ b/modules/configs/templates/cloud-init/cloud-config.yaml
@@ -45,7 +45,7 @@ write_files:
 - path: /etc/ptfe/custom-ca-cert-url
   owner: root:root
   permissions: "0400"
-  content: "${ca_cert_url}"
+  content: "${ca_bundle_url}"
 
 %{~ if role != "secondary" ~}
 - path: /etc/ptfe/setup-token

--- a/modules/configs/variables.tf
+++ b/modules/configs/variables.tf
@@ -85,7 +85,7 @@ variable "repl_cidr" {
 
 # === Optional
 
-variable "ca_cert_url" {
+variable "ca_bundle_url" {
   type        = "string"
   description = "URL to CA certificate file used for the internal `ptfe-proxy` used for outgoing connections"
   default     = "none"

--- a/variables.tf
+++ b/variables.tf
@@ -66,9 +66,9 @@ variable "airgap_package_url" {
   default     = ""
 }
 
-variable "ca_cert_url" {
+variable "ca_bundle_url" {
   type        = "string"
-  description = "URL to CA certificate file used for the internal `ptfe-proxy` used for outgoing connections"
+  description = "URL to Custom CA bundle used for outgoing connections"
   default     = "none"
 }
 


### PR DESCRIPTION
Related to https://github.com/hashicorp/terraform-google-terraform-enterprise/pull/16 and https://github.com/hashicorp/terraform-aws-terraform-enterprise/pull/17

Quoting https://github.com/hashicorp/terraform-aws-terraform-enterprise/pull/17:

> This PR fixes an issue where the ca_cert_url would error out while trying to retrieve it.
> 
> There were two problems:
> 
> 1. It attempted to use `/tmp/ptfe/customer-certs` as a working dir, but the downloaded `ptfe` tool was still in the `/tmp` dir causing it to collide and error out.
> 2. `wget` was passed an arg it did not recognize.
> 
> Couple quick fixes and it works! 🎉
> 
> Part 2 of this PR is something that's easy to revert and I'm open to it this late in the game but I changed the variable to `ca_bundle_url`. I did this to better match the terminology we use in the settings UI and to denote that this can be a whole bundle and not just a single cert.
> 
> These fixes may need to be applied to Azure and GCP once this is merged (and if we do go with the rename we'll need to make those match for ease of use).

