### PR TITLE
Airgap Fix

### DIFF
--- a/modules/configs/templates/replicated/replicated.conf
+++ b/modules/configs/templates/replicated/replicated.conf
@@ -1,4 +1,18 @@
 {
+%{ if release_sequence != "latest" ~}
+    "ReleaseSequence":                   "${release_sequence}",
+%{ endif ~}
+%{ if installation_mode == "es" ~}
+%{ if airgap == "True" ~}
+%{ else ~}
+    "HttpProxy":                         "${proxy_url}",
+%{ endif ~}
+%{ else ~}
+    "HttpProxy":                         "${proxy_url}",
+%{ endif ~}
+%{ if airgap == "True" ~}
+    "LicenseBootstrapAirgapPackagePath": "/var/lib/ptfe/ptfe.airgap",
+%{ endif ~}
     "DaemonAuthenticationType":          "password",
     "DaemonAuthenticationPassword":      "${console_password}",
     "TlsBootstrapType":                  "server-path",
@@ -7,19 +21,5 @@
     "TlsBootstrapKey":                   "/etc/ptfe/tls.key",
     "BypassPreflightChecks":             true,
     "ImportSettingsFrom":                "/etc/replicated-ptfe.conf",
-    "LicenseFileLocation":               "/etc/replicated.rli",
-%{ if release_sequence != "latest" ~}
-    "ReleaseSequence":                   "${release_sequence}"
-%{ endif ~}
-%{ if installation_mode == "es" ~}
-%{ if airgap == "True" ~}
-%{ else ~}
-    "HttpProxy":                         "${proxy_url}"
-%{ endif ~}
-%{ else ~}
-    "HttpProxy":                         "${proxy_url}"
-%{ endif ~}
-%{ if airgap == "True" ~}
-    "LicenseBootstrapAirgapPackagePath": "/var/lib/ptfe/ptfe.airgap"
-%{ endif ~}
+    "LicenseFileLocation":               "/etc/replicated.rli"
 }


### PR DESCRIPTION
## Background

while testing the airgap mode, the config json file was missing a trailing comma on the second to last key:val due to attempts to have the templating logic handle json's lack of a trailing comma on the last item. This PR forces a static value to be the final k:v pair so it should always be proper json.

