### PR TITLE
Update broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Please see the [examples directory](https://github.com/hashicorp/terraform-azure
 
 ## Inputs
 
-Please see the [inputs documentation](https://registry.terraform.io/modules/hashicorp/terraform-enterprise/azurerm?tab=inputs)
+Please see the [inputs documentation](https://registry.terraform.io/modules/hashicorp/terraform-enterprise/azurerm/?tab=inputs)
 
 Repository versions of the inputs documentation can be found in [docs/inputs.md](docs/inputs.md)
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Please see the [examples directory](https://github.com/hashicorp/terraform-azure
 
 ## Inputs
 
-Please see the [inputs documentation](https://registry.terraform.io/modules/hashicorp/terraform-enterprise/azurerm/?tab=inputs)
+Please see the [inputs documentation](https://registry.terraform.io/modules/hashicorp/terraform-enterprise/azurerm?tab=inputs)
 
 Repository versions of the inputs documentation can be found in [docs/inputs.md](docs/inputs.md)
 

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,6 +1,6 @@
 # Terraform Enterprise with Clustering - Basic example
 
-This is a basic example of how to set up the configurations to use this module. Please see the [inputs page](https://registry.terraform.io/modules/terraform-enterprise/azurerm/?tab=inputs) for more details on usage.
+This is a basic example of how to set up the configurations to use this module. Please see the [inputs page](https://registry.terraform.io/modules/hashicorp/terraform-enterprise/azurerm?tab=inputs) for more details on usage.
 
 ## Prerequisites
 


### PR DESCRIPTION
Fixes: #39 

The URLs for the input page in the example README currently 404s. This PR updates it to the correct URL. 🎉 