### PR TITLE
Add diff to fmt check to show what needs to be changed in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - checkout
       - run:
           name: Check terraform formatting
-          command: terraform fmt -check=true -write=false
+          command: terraform fmt -check=true -write=false -diff
   validation_check:
     working_directory: ~
     docker:


### PR DESCRIPTION
Much like https://github.com/hashicorp/terraform-aws-terraform-enterprise/pull/43 

When CI comes back with a failure on the fmt check it only lists the files that have issues but not the issues themselves. This adds the `-diff` flag to show what it'd change/what it wants.