### PR TITLE
Add optional hostname variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,7 @@ module "cluster_lb" {
   rg_name         = "${module.common.rg_name}"
   location        = "${module.common.rg_location}"
   resource_prefix = "${var.resource_prefix}"
+  hostname        = "${var.hostname}"
 
   dns = {
     domain  = "${var.domain}"

--- a/modules/cluster_lb/dns.tf
+++ b/modules/cluster_lb/dns.tf
@@ -12,7 +12,7 @@ resource "azurerm_dns_a_record" "api" {
 }
 
 resource "azurerm_dns_a_record" "application" {
-  name                = "${local.prefix}"
+  name                = "${local.frontened_hostname}"
   zone_name           = "${data.azurerm_dns_zone.selected.name}"
   resource_group_name = "${var.dns["rg_name"]}"
   ttl                 = "${var.dns["ttl"]}"

--- a/modules/cluster_lb/variables.tf
+++ b/modules/cluster_lb/variables.tf
@@ -41,11 +41,17 @@ variable "lb_probe_unhealthy_threshold" {
   description = "The amount of unhealthy checks before marking a node unhealthy."
 }
 
+variable "hostname" {
+  default     = ""
+  description = "hostname for loadbalancer front end to use"
+}
+
 # ============================================================ MISC
 
 # LB resource names
 
 locals {
-  prefix   = "${var.resource_prefix}-${var.install_id}"
-  frontend = "${local.prefix}-fe"
+  prefix             = "${var.resource_prefix}-${var.install_id}"
+  frontend           = "${local.prefix}-fe"
+  frontened_hostname = "${var.hostname != "" ? var.hostname : local.prefix }"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -120,6 +120,11 @@ variable "encryption_password" {
   default     = ""
 }
 
+variable "hostname" {
+  description = "Hostname for loadbalancer frontend to use, otherwise will default to 'tfe-$install_id.domain.com'"
+  default     = ""
+}
+
 variable "http_proxy_url" {
   type        = "string"
   description = "HTTP(S) Proxy URL"


### PR DESCRIPTION
Some customers want to specify their own hostname. This can be because they cannot use wild card certs, or this could be just to have a more consistent or memorable name. We allow this in the GCP and AWS modules but it wasn't yet in Azure, this PR hopes to address that. 🎉 

A couple things: 

1. It's still a subdomain of whatever the DNS zone managed is. This is consistent with AWS and I think GCP as well. 
2. If you don't set a hostname, we fallback to the previous behavior of `tfe-[install_id]` for the frontend. 
3. We assume that the certificate you supply is valid for the domain you supply. Which is no different than now, but figured all cert things are worth mentioning a lot. 😁 