### PR TITLE
Ensure encryption password is set for external services.

### DIFF
--- a/modules/configs/templates/replicated/replicated-ptfe.conf
+++ b/modules/configs/templates/replicated/replicated-ptfe.conf
@@ -1,20 +1,17 @@
 {
     "hostname": {
         "value": "${app_endpoint}"
+    },
+    "enc_password": {
+        "value": "${enc_password}"
 %{ if installation_mode != "es" ~}
     },
     "installation_type": {
         "value": "poc"
-    },
-    "enc_password": {
-        "value": "${enc_password}"
 %{ else ~}
     },
     "installation_type": {
         "value": "production"
-    },
-    "enc_password": {
-        "value": "${enc_password}"
     },
     "production_type": {
         "value": "external"

--- a/modules/configs/templates/replicated/replicated-ptfe.conf
+++ b/modules/configs/templates/replicated/replicated-ptfe.conf
@@ -6,12 +6,15 @@
     "installation_type": {
         "value": "poc"
     },
-     "enc_password": {
-     "value": "${enc_password}"
+    "enc_password": {
+        "value": "${enc_password}"
 %{ else ~}
     },
     "installation_type": {
         "value": "production"
+    },
+    "enc_password": {
+        "value": "${enc_password}"
     },
     "production_type": {
         "value": "external"


### PR DESCRIPTION
Background

Current installation using external services does not use the provided encryption password and leaves the cluster in an unsteady state if the cluster is blown away while leaving the external services in tact.

Updated the configuration to use the encryption password if provided, or the dynamically generated password if not provided.

How Has This Been Tested

Tested this using the same fixture for v0.1.0 but swapping out sources for this repo/branch.