### PR TITLE
Move CircleCI to 0.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
 jobs:
   format_check:
     docker:
-      - image: "hashicorp/terraform:0.11.14"
+      - image: "hashicorp/terraform:0.12.13"
     steps:
       - checkout
       - run:
@@ -19,7 +19,7 @@ jobs:
   validation_check:
     working_directory: ~
     docker:
-      - image: "hashicorp/terraform:0.11.14"
+      - image: "hashicorp/terraform:0.12.13"
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## Background

https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/pull/49 brought in the 0.12 changes but CI wasn't updated to run in 0.12. This PR fixes this issue by having it run via 0.12. 

## How Has This Been Tested

By opening this PR Circle will start testing it! :tada: 

## This PR makes me feel

![Excited bird runs circles around some coffee](https://media.giphy.com/media/koTAN2V1PTOzC/giphy.gif)
