### PR TITLE
Separate VNET Resource Group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 module "common" {
-  source          = "./modules/common"
-  install_id      = random_string.install_id.result
-  rg_name         = var.resource_group_name
+  source     = "./modules/common"
+  install_id = random_string.install_id.result
+  rg_name    = var.resource_group_name
   vnet = {
     name    = var.virtual_network_name
     rg_name = var.virtual_network_resource_group_name

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,10 @@ module "common" {
   source          = "./modules/common"
   install_id      = random_string.install_id.result
   rg_name         = var.resource_group_name
-  vnet_name       = var.virtual_network_name
+  vnet = {
+    name    = var.virtual_network_name
+    rg_name = var.virtual_network_resource_group_name
+  }
   subnet_name     = var.subnet
   resource_prefix = var.resource_prefix
   additional_tags = var.additional_tags

--- a/modules/common/data.tf
+++ b/modules/common/data.tf
@@ -3,14 +3,14 @@ data "azurerm_resource_group" "selected" {
 }
 
 data "azurerm_virtual_network" "selected" {
-  name                = var.vnet_name
-  resource_group_name = var.rg_name
+  name                = var.vnet["name"]
+  resource_group_name = local.rendered_vnet_rg_name
 }
 
 data "azurerm_subnet" "app_selected" {
   name                 = var.subnet_name
-  resource_group_name  = var.rg_name
-  virtual_network_name = var.vnet_name
+  resource_group_name  = local.rendered_vnet_rg_name
+  virtual_network_name = var.vnet["name"]
 }
 
 data "azurerm_resource_group" "kv_selected" {

--- a/modules/common/variables.tf
+++ b/modules/common/variables.tf
@@ -10,9 +10,12 @@ variable "rg_name" {
   description = "The Azure Resource Group to build into"
 }
 
-variable "vnet_name" {
-  type        = string
-  description = "The Azure Virtual Network to build into"
+variable "vnet" {
+  type = object({
+    name    = string
+    rg_name = string
+  })
+  description = "Expects keys: [name, rg_name] (The Azure Virtual Network to build into and the resource group of the Virtual Network"
 }
 
 variable "subnet_name" {
@@ -75,6 +78,7 @@ locals {
   prefix                  = "${var.resource_prefix}-${var.install_id}"
   rendered_kv_rg_name     = coalesce(var.key_vault["rg_name"], var.rg_name)
   rendered_domain_rg_name = coalesce(var.domain_rg_name, var.rg_name)
+  rendered_vnet_rg_name   = coalesce(var.vnet["rg_name"], var.rg_name)
   
   default_tags = {
     Application = "Terraform Enterprise"

--- a/variables.tf
+++ b/variables.tf
@@ -256,6 +256,12 @@ variable "tls_pfx_certificate_key_type" {
   default     = "RSA"
 }
 
+variable "virtual_network_resource_group_name" {
+  type        = string
+  description = "The existing Azure Resource Group where the virtual network resides, defaults to the main resource group if not set."
+  default     = ""
+}
+
 variable "vm_size_tier" {
   type        = string
   description = "The tier for the vms (must be 'Standard' or 'Basic') and must match with vm_size"


### PR DESCRIPTION
Create a variable for a separate VNET Resource Group similar to Key Vault.

Relates OR Closes #67.  

Feel free to ignore this pull request post your 0.12 rework.  Who knows maybe it will merge.  If you don't get to it post 0.12 I can take another run at reworking it for the latest changes.

## How Has This Been Tested

Ran it in my own subscription

### Test Configuration

* Terraform Version: 0.12.18

## This PR makes me feel

Great


