### PR TITLE
Fix install script issue (again)

### DIFF
--- a/modules/configs/files/install-ptfe.sh
+++ b/modules/configs/files/install-ptfe.sh
@@ -19,11 +19,10 @@ if [ -f /etc/redhat-release ]; then
   mkdir -p /lib/tc
   mount --bind /usr/lib64/tc/ /lib/tc/
   sed -i -e 's/^SELINUX=enforcing/SELINUX=permissive/' /etc/sysconfig/selinux
-  sed -i -e '/rhui-REGION-rhel-server-extras/,/^$/s/enabled=0/enabled=1/g'  /etc/yum.repos.d/redhat-rhui.repo
-  yum -y install docker wget jq chrony ipvsadm unzip
-  # remove after testing rhui?
-  # curl -sfSL -o /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
-  # chmod +x /usr/bin/jq
+  #sed -i -e '/rhui-REGION-rhel-server-extras/,/^$/s/enabled=0/enabled=1/g'  /etc/yum.repos.d/redhat-rhui.repo
+  yum -y install docker wget chrony ipvsadm unzip
+  curl -sfSL -o /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+  chmod +x /usr/bin/jq
   systemctl enable docker
   systemctl start docker
 else


### PR DESCRIPTION
## Background

Install script will fail. 2 issues happening here - 1) the repo setup stuff isn't necessary on azure, and jq needs to be dl'd - it's not in the RH repo. 


Closes #15 


## How Has This Been Tested

This is a re-release of a previous fix - https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/pull/26/files

## This PR makes me feel

![](https://media.giphy.com/media/TIhCRE9RVPlS0/giphy.gif)
