### PR TITLE
Don't overwrite /etc/sysconfig/selinux symlink

### DIFF
--- a/modules/configs/files/install-ptfe.sh
+++ b/modules/configs/files/install-ptfe.sh
@@ -23,7 +23,7 @@ if [ -f /etc/redhat-release ]; then
   setenforce 0
   mkdir -p /lib/tc
   mount --bind /usr/lib64/tc/ /lib/tc/
-  sed -i -e 's/^SELINUX=enforcing/SELINUX=permissive/' /etc/sysconfig/selinux
+  sed -i --follow-symlinks -e 's/^SELINUX=enforcing/SELINUX=permissive/' /etc/sysconfig/selinux
   #sed -i -e '/rhui-REGION-rhel-server-extras/,/^$/s/enabled=0/enabled=1/g'  /etc/yum.repos.d/redhat-rhui.repo
   yum -y install docker wget chrony ipvsadm unzip
   curl -sfSL -o /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64


### PR DESCRIPTION
## Background

The `install-ptfe.sh` script on RHEL tries to modify `/etc/sysconfig/selinux` in place using `sed` in order to disable SELinux. Since that file is a symlink to `/etc/selinux/config` on modern versions of RHEL, `sed` needs the `--follow-symlinks` option or it will overwrite the file and remove the symlink. This could cause undesirable results including not actually disabling SELinux across reboots as intended.

Closes #74 

## How Has This Been Tested

Ran the updated command on a RHEL 7.6 image on Azure. It preserved the symlink and correctly updated the file.
