### PR TITLE
Add Azure Blob Storage endpoint variable

### DIFF
--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -18,6 +18,7 @@
 | azure\_es\_account\_key | The Azure account key for external services | string | `""` | no |
 | azure\_es\_account\_name | The Azure account name for external services | string | `""` | no |
 | azure\_es\_container | The Azure container for external services | string | `""` | no |
+| azure\_es\_endpoint | The Azure endpoint for external services | string | `"core.windows.net"` | no |
 | ca\_bundle\_url | URL to Custom CA bundle used for outgoing connections | string | `""` | no |
 | distribution | Type of linux distribution to use. (ubuntu or rhel) | string | `"ubuntu"` | no |
 | dns\_ttl | The TTL for dns records. | string | `"120"` | no |

--- a/main.tf
+++ b/main.tf
@@ -88,6 +88,7 @@ module "configs" {
     account_name = var.azure_es_account_name
     account_key  = var.azure_es_account_key
     container    = var.azure_es_container
+    endpoint     = var.azure_es_endpoint
   }
 
   airgap = {

--- a/modules/configs/cloud-init.tf
+++ b/modules/configs/cloud-init.tf
@@ -36,6 +36,7 @@ data "template_file" "replicated_ptfe_config" {
     azure_account_name     = var.azure_es["account_name"]
     azure_account_key      = var.azure_es["account_key"]
     azure_container        = var.azure_es["container"]
+    azure_endpoint         = var.azure_es["endpoint"]
   }
 }
 

--- a/modules/configs/docs/inputs.md
+++ b/modules/configs/docs/inputs.md
@@ -6,7 +6,7 @@
 |------|-------------|:----:|:-----:|:-----:|
 | airgap | Expects keys: [enable, package_url, installer_url] | map | n/a | yes |
 | assistant\_port | Port the assitant sidecar-like node service is running on. | string | n/a | yes |
-| azure\_es | Expects keys: [enable, account_name, account_key, container] | map | n/a | yes |
+| azure\_es | Expects keys: [enable, account_name, account_key, container, endpoint] | map | n/a | yes |
 | ca\_bundle\_url | URL to CA certificate file used for the internal `ptfe-proxy` used for outgoing connections | string | n/a | yes |
 | cert\_thumbprint | The thumbprint for the Azure Key Vault Certificate object generated from the provided PFX certificate. | string | n/a | yes |
 | cluster\_api\_endpoint | URI to the cluster api | string | n/a | yes |

--- a/modules/configs/templates/replicated/replicated-ptfe.conf
+++ b/modules/configs/templates/replicated/replicated-ptfe.conf
@@ -42,6 +42,9 @@
     },
     "azure_container": {
         "value": "${azure_container}"
+    },
+    "azure_endpoint": {
+        "value": "${azure_endpoint}"
 
 %{ endif ~}
     },

--- a/modules/configs/variables.tf
+++ b/modules/configs/variables.tf
@@ -84,8 +84,9 @@ variable "azure_es" {
     account_name = string
     account_key  = string
     container    = string
+    endpoint     = string
   })
-  description = "Expects keys: [enable, account_name, account_key, container]"
+  description = "Expects keys: [enable, account_name, account_key, container, endpoint]"
 }
 
 variable "airgap" {

--- a/variables.tf
+++ b/variables.tf
@@ -96,6 +96,12 @@ variable "azure_es_container" {
   default     = ""
 }
 
+variable "azure_es_endpoint" {
+  type        = string
+  description = "The Azure endpoint for external services"
+  default     = "core.windows.net"
+}
+
 variable "distribution" {
   type        = string
   description = "Type of linux distribution to use. (ubuntu or rhel)"


### PR DESCRIPTION
## Background

When using external services with Azure Blob Storage for the S3-compatible storage, Terraform Enterprise is unable to communicate with Azure Blob Storage since the `azure_endpoint` configuration option in the Replicated application settings defaults to a blank value and is then generated malformed in Terraform Enterprise. This pull request ensures the `azure_endpoint` configuration option in the Replicated application settings will default to `core.windows.net` while allowing users to provide their own value via the `azure_es_endpoint` input.

## How Has This Been Tested

Ran `terraform init` and `terraform validate`.

### Test Configuration

* Terraform Version: 0.11.14
* Any additional relevant variables: `azure_es_endpoint`

## This PR makes me feel

![](https://media.giphy.com/media/12BVRyyZASUOo8/giphy.gif)
