### PR TITLE
Fix destroy issue by adding depends_on for pool association

### DIFF
--- a/modules/primaries/vms.tf
+++ b/modules/primaries/vms.tf
@@ -1,6 +1,6 @@
 resource "azurerm_virtual_machine" "primary" {
   # The number of primaries must be hard coded to 3 when Internal Production Mode
-  # is selected. Currently, that mode does not support scaling. In other modes, the 
+  # is selected. Currently, that mode does not support scaling. In other modes, the
   # cluster can be scaled according the primary_count variable.
   count = local.install_type == "ipm" ? 3 : var.vm["count"]
 
@@ -13,6 +13,8 @@ resource "azurerm_virtual_machine" "primary" {
 
   network_interface_ids         = [azurerm_network_interface.primary[count.index].id]
   delete_os_disk_on_termination = true
+
+  depends_on = [azurerm_network_interface_backend_address_pool_association.ptfe_api]
 
   os_profile_linux_config {
     disable_password_authentication = true


### PR DESCRIPTION
## Background

During destroys in development often I would find myself with an error causing it to fail that looked like: 

```
Error: Error waiting for removal of Backend Address Pool Association for NIC "tfe-90eba3lw-primary-2" (Resource Group "tfe-bnferguson-new-rg"): Code="OperationNotAllowed" Message="Operation 'startTenantUpdate' is not allowed on VM 'tfe-90eba3lw-primary-2' since the VM is marked for deletion. You can only retry the Delete operation (or wait for an ongoing one to complete)." Details=[]
```

Digging around this issue I found https://github.com/terraform-providers/terraform-provider-azurerm/issues/4330 and `tombuildsstuff` (avoiding ping since he's super busy :) ) tipped me off where the break might be. Turns out he was right and that got it right sorted. 🙇 🎉 

## How Has This Been Tested

Multiple terraform apply/destroys to confirm it was gone. :) 

### Test Configuration

* Terraform Version: v0.12.18
* Any additional relevant variables: `provider.azurerm v1.44.0`

## This PR makes me feel

![I feel like a successful baby](https://media.giphy.com/media/4xpB3eE00FfBm/giphy-downsized.gif)
