### PR TITLE
Add additional_no_proxy variable, wire proxy options into install.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -62,6 +62,7 @@ module "configs" {
   cert_thumbprint      = module.common.cert_thumbprint
   assistant_port       = local.assistant_port
   http_proxy_url       = var.http_proxy_url
+  additional_no_proxy  = var.additional_no_proxy
   installer_url        = var.installer_url
   import_key           = var.import_key
   ca_bundle_url        = var.ca_bundle_url

--- a/modules/configs/cloud-init.tf
+++ b/modules/configs/cloud-init.tf
@@ -39,13 +39,6 @@ data "template_file" "replicated_ptfe_config" {
   }
 }
 
-data "template_file" "proxy_sh" {
-  template = file("${path.module}/templates/cloud-init/proxy.sh")
-
-  vars = {
-    proxy_url = var.http_proxy_url
-  }
-}
 
 data "template_file" "aaa_proxy_b64" {
   template = file("${path.module}/templates/cloud-init/00aaa_proxy")
@@ -64,18 +57,19 @@ data "template_file" "cloud_config" {
     airgap_installer_url = var.airgap["installer_url"]
     setup_token          = random_string.setup_token.result
     proxy_url            = var.http_proxy_url
+    additional_no_proxy  = var.additional_no_proxy
     ptfe_url             = var.installer_url
     role_id              = count.index
     import_key           = var.import_key
     distro               = var.distribution
     aaa_proxy_b64        = base64encode(data.template_file.aaa_proxy_b64.rendered)
-    proxy_b64            = base64encode(data.template_file.proxy_sh.rendered)
     bootstrap_token      = "${random_string.bootstrap_token_id.result}.${random_string.bootstrap_token_suffix.result}"
     license_b64          = filebase64(var.license_file)
     rptfeconf            = base64encode(data.template_file.replicated_ptfe_config.rendered)
     replconf             = base64encode(data.template_file.replicated_config.rendered)
     install_ptfe_sh      = filebase64("${path.module}/files/install-ptfe.sh")
     role                 = count.index == 0 ? "main" : "primary"
+    cluster_api_lb       = "${var.cluster_api_endpoint}"
     cluster_api_endpoint = "${var.cluster_api_endpoint}:6443"
     assistant_host       = "http://${var.cluster_api_endpoint}:${var.assistant_port}"
     cert_thumbprint      = var.cert_thumbprint
@@ -101,17 +95,18 @@ data "template_file" "cloud_config_secondary" {
 
   vars = {
     proxy_url            = var.http_proxy_url
+    additional_no_proxy  = var.additional_no_proxy
     ptfe_url             = var.installer_url
     import_key           = var.import_key
     bootstrap_token      = "${random_string.bootstrap_token_id.result}.${random_string.bootstrap_token_suffix.result}"
     cluster_api_endpoint = "${var.cluster_api_endpoint}:6443"
+    cluster_api_lb       = "${var.cluster_api_endpoint}"
     assistant_host       = "http://${var.cluster_api_endpoint}:${var.assistant_port}"
     setup_token          = random_string.setup_token.result
     install_ptfe_sh      = filebase64("${path.module}/files/install-ptfe.sh")
     role                 = "secondary"
     distro               = var.distribution
     aaa_proxy_b64        = base64encode(data.template_file.aaa_proxy_b64.rendered)
-    proxy_b64            = base64encode(data.template_file.proxy_sh.rendered)
     ca_bundle_url        = var.ca_bundle_url
   }
 }

--- a/modules/configs/files/install-ptfe.sh
+++ b/modules/configs/files/install-ptfe.sh
@@ -6,13 +6,23 @@ set -e -u -o pipefail
 if [ -s /etc/ptfe/proxy-url ]; then
   http_proxy=$(cat /etc/ptfe/proxy-url)
   https_proxy=$(cat /etc/ptfe/proxy-url)
+  api_load_balancer_without_port=$(cat /etc/ptfe/cluster-api-endpoint | awk -F ":" '/1/ {print $1}')
   export http_proxy
   export https_proxy
-  export no_proxy=10.0.0.0/8,127.0.0.1,169.254.169.254
+  export no_proxy=10.0.0.0/8,127.0.0.1,169.254.169.254,"$api_load_balancer_without_port"
+
+  # Add custom CIDR range for Replicated to no_proxy if set
   if [[ $(< /etc/ptfe/repl-cidr) != "" ]]; then
       repl_cidr=$(cat /etc/ptfe/repl-cidr)
       export repl_cidr
       export no_proxy=$no_proxy,$repl_cidr
+  fi
+
+  # Add additional_no_proxy items to no_proxy if set
+  if [[ $(< /etc/ptfe/additional-no-proxy) != "" ]]; then
+      additional_no_proxy=$(cat /etc/ptfe/additional-no-proxy)
+      export additional_no_proxy
+      export no_proxy=$no_proxy,$additional_no_proxy
   fi
 fi
 
@@ -70,11 +80,6 @@ airgap_url_path="/etc/ptfe/airgap-package-url"
 airgap_installer_url_path="/etc/ptfe/airgap-installer-url"
 weave_cidr="/etc/ptfe/weave-cidr"
 repl_cidr="/etc/ptfe/repl-cidr"
-
-
-
-
-
 health_url="$(cat /etc/ptfe/health-url)"
 
 ptfe_install_args=(
@@ -95,6 +100,13 @@ if test -e /etc/ptfe/role-id; then
     )
 fi
 
+if [ -s /etc/ptfe/proxy-url ]; then
+    ptfe_install_args+=(
+        "--additional-no-proxy=$no_proxy"
+        "--http-proxy=$http_proxy"
+    )
+fi
+
 if [ "x${role}x" == "xmainx" ]; then
     verb="setup"
     export verb
@@ -106,11 +118,6 @@ if [ "x${role}x" == "xmainx" ]; then
         "--auth-token=@/etc/ptfe/setup-token"
     )
 
-    if [ -s /etc/ptfe/proxy-url ]; then
-        ptfe_install_args+=(
-            "--additional-no-proxy=$no_proxy"
-        )
-    fi
     # If we are airgapping, then set the arguments needed for Replicated.
     # We also setup the replicated.conf.tmpl to include the path to the downloaded
     # airgap file.

--- a/modules/configs/templates/cloud-init/cloud-config.yaml
+++ b/modules/configs/templates/cloud-init/cloud-config.yaml
@@ -51,6 +51,11 @@ write_files:
   permissions: "0400"
   content: "${proxy_url}"
 
+- path: /etc/ptfe/additional-no-proxy
+  owner: root:root
+  permissions: "0400"
+  content: "${additional_no_proxy}"
+
 %{ if ca_bundle_url != "" }
 - path: /etc/ptfe/custom-ca-cert-url
   owner: root:root
@@ -73,22 +78,21 @@ write_files:
   permissions: "0444"
   content: "${role_id}"
 
-- path: /etc/profile.d/proxy.sh
-  owner: root:root
-  permissions: "0755"
-  encoding: b64
-  content: ${proxy_b64}
 
-%{ if repl_cidr != "" }
 - path: /etc/profile.d/proxy.sh
   owner: root:root
   permissions: "0755"
   content: |
     export http_proxy="${proxy_url}"
     export https_proxy="${proxy_url}"
-    export no_proxy=10.0.0.0/8,127.0.0.1,169.254.169.254,${repl_cidr}
+    export no_proxy=10.0.0.0/8,127.0.0.1,169.254.169.254,${cluster_api_lb}
+%{ if additional_no_proxy != "" }
+    export no_proxy=$no_proxy,${additional_no_proxy}
 %{ endif }
-  
+%{ if repl_cidr != "" }
+    export no_proxy=$no_proxy,${repl_cidr}
+%{ endif }
+
 %{ endif ~}
 %{ if role == "main" }
 - path: /etc/replicated.rli

--- a/modules/configs/templates/cloud-init/proxy.sh
+++ b/modules/configs/templates/cloud-init/proxy.sh
@@ -1,3 +1,0 @@
-export http_proxy="${proxy_url}"
-export https_proxy="${proxy_url}"
-export no_proxy=10.0.0.0/8,127.0.0.1,169.254.169.254

--- a/modules/configs/variables.tf
+++ b/modules/configs/variables.tf
@@ -49,6 +49,12 @@ variable "http_proxy_url" {
   description = "HTTP(S) Proxy URL"
 }
 
+variable "additional_no_proxy" {
+  type        = string
+  description = "Comma delimitted list of addresses (no spaces) to not use the proxy for"
+  default     = ""
+}
+
 variable "installer_url" {
   type        = string
   description = "URL to the cluster installer tool"

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,12 @@ variable "resource_prefix" {
   default     = "tfe"
 }
 
+variable "additional_no_proxy" {
+  type        = string
+  description = "Comma delimitted list of addresses (no spaces) to not use the proxy for"
+  default     = ""
+}
+
 variable "airgap_installer_url" {
   type        = string
   description = "URL to replicated's airgap installer package"


### PR DESCRIPTION
## Background

The Azure implementation of https://github.com/hashicorp/terraform-aws-terraform-enterprise/pull/56. From that issue: 

> We've seen issues with customers that use proxies having issues with cluster creation depending their network setups. One possible problem for this is that we don't currently allow for adding to the no_proxy list at install time.
>
> Replicated does autodetect http_proxy (though I've made it explicit here) but it does not detect no_proxy other than the defaults it sets itself (for its own communication). So this PR is wiring that in.

## How Has This Been Tested

Tested this by spinning up an Azure cluster with a proxy in front of it and confirming it properly installs and runs. 

### Test Configuration

* Terraform Version: `Terraform v0.12.18`
* Any additional relevant variables: 

## This PR makes me feel

![Wires wires wires!](https://media.giphy.com/media/DvslEtE5ICO3e/giphy-downsized.gif)
