### PR TITLE
[Backport] Ensure encryption password is set for external services. (#65)

### DIFF
--- a/modules/configs/templates/replicated/replicated-ptfe.conf
+++ b/modules/configs/templates/replicated/replicated-ptfe.conf
@@ -1,13 +1,13 @@
 {
     "hostname": {
         "value": "${app_endpoint}"
+    },
+    "enc_password": {
+        "value": "${enc_password}"
 %{ if installation_mode != "es" ~}
     },
     "installation_type": {
         "value": "poc"
-    },
-     "enc_password": {
-     "value": "${enc_password}"
 %{ else ~}
     },
     "installation_type": {


### PR DESCRIPTION
## Background

This is a `v0.1.x` series backport of https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/pull/65. Currently there are issues with the v0.1.x series and External Services causing machines to be redployed on change which they shouldn't. This is blocking some customers rollouts as mentioned in https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/issues/68#issuecomment-586523795


## How Has This Been Tested

Refer to https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/pull/65

## This PR makes me feel

![Cleeeeaning up things](https://media.giphy.com/media/G03AbJi6AeJOw/giphy-downsized.gif)
