### PR TITLE
Upgrade Ubuntu 16.04 to 18.04

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -245,7 +245,7 @@ variable "storage_image" {
   default = {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    sku       = "18.04-LTS"
     version   = "latest"
   }
 }


### PR DESCRIPTION
## Background

Closes https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/issues/53

The default storage image for Ubuntu right now is 16.04. This PR gets us on a more up to date version. There were some issues in the past with the newer image when this module was created but these have been sorted out nw so lets get this up to date! 🎉 


## How Has This Been Tested

Spun up a new cluster with this PR and tested that it worked. (It did. 💃) 

### Test Configuration

* Terraform Version: 0.12.18

## This PR makes me feel

![Upgrading a computer with a floppy disk](https://media.giphy.com/media/Gz1hvMChvYvW8/giphy.gif)
