### PR TITLE
Fix validation step in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           command: echo -e "license_file = \"~/fake.rli\"\nresource_group_name = \"fake-rg\"\nvirtual_network_name = \"fake-vnet\"\nsubnet = \"fake-subnet\"\nkey_vault_name = \"fake-kv\"\ndomain = \"example.com\"\ntls_pfx_certificate = \"~/temp.pfx\"\ntls_pfx_certificate_password = \"fake-password\"" > terraform.tfvars
       - run:
           name: create provider stub
-          command: echo -e "provider \"azurerm\" {}\n" > provider.tf
+          command: echo -e "provider \"azurerm\" {\nversion= \"=1.44.0\"\nfeatures {}\n}\n" > provider.tf
       - run:
           name: init configs and check if valid
           command: terraform init && terraform validate


### PR DESCRIPTION
## Background

Noticed in some PRs that CI started breaking for the validation step with the error: 

```
Error: "features": required field is not set
```

When the `azurerm` provider was at 2.0. We don't currently fix the CI to versions like we do when we run the modules. So this PR looks to fix that. 


## How Has This Been Tested

I opened this PR, and then gonna watch CI pass or fail. ~Maybe push a bunch of commits while sobbing quietly and muttering about CI not passing as I fix issues~ (Oh! got a green check!).


### Test Configuration

* Terraform Version: 0.12.21
* Any additional relevant variables:
```
+ provider.azurerm v1.44.0
+ provider.local v1.4.0
+ provider.null v2.1.2
+ provider.random v2.2.1
+ provider.template v2.1.2
+ provider.tls v2.1.1
```
## This PR makes me feel

![I was literally watching spiderman while fixing this on the Airplane so here's a spiderman gif with a wrench hitting things](https://media.giphy.com/media/6qdKZFhT0VBm0/giphy-downsized.gif)
