### PR TITLE
Update docs-gen.sh, generate new updated docs

### DIFF
--- a/.scripts/doc-gen.sh
+++ b/.scripts/doc-gen.sh
@@ -4,10 +4,10 @@ set -e
 
 BINARY_DIR=./work
 BINARY_FILE="${BINARY_DIR}/terraform-docs"
-BINARY_VERSION=0.6.0
+BINARY_VERSION=0.8.2
 BINARY_URL_PREFIX="https://github.com/segmentio/terraform-docs/releases/download/v${BINARY_VERSION}/terraform-docs-v${BINARY_VERSION}"
 
-DOCS_CMDS="--sort-inputs-by-required --with-aggregate-type-defaults markdown table"
+DOCS_CMDS="--sort-by-required --no-header markdown table"
 DOCS_DIR=docs
 
 VARS_TF=variables.tf
@@ -25,8 +25,8 @@ function setup {
         elif [[ "$OSTYPE" == "darwin"* ]]; then
             BINARY_URL="${BINARY_URL_PREFIX}-darwin-amd64"
         else
-            echo "Please run this in either a Linux or Mac environment."     
-            exit 1  
+            echo "Please run this in either a Linux or Mac environment."
+            exit 1
         fi
         echo "Downloading ${BINARY_URL}"
         curl -L -o "${BINARY_FILE}" "${BINARY_URL}"
@@ -41,8 +41,8 @@ function main_docs {
 
     echo -e "# Terraform Enterprise: Clustering\n" | tee "${DOCS_DIR}/${INS_MD}" "${DOCS_DIR}/${OUTS_MD}" &> /dev/null
 
-    eval "${BINARY_FILE} ${DOCS_CMDS} ${VARS_TF}"  >> "${DOCS_DIR}/${INS_MD}"
-    eval "${BINARY_FILE} ${DOCS_CMDS} ${OUTS_TF}" >> "${DOCS_DIR}/${OUTS_MD}"
+    eval "${BINARY_FILE} ${DOCS_CMDS} --no-outputs --no-providers" . >> "${DOCS_DIR}/${INS_MD}"
+    eval "${BINARY_FILE} ${DOCS_CMDS} --no-inputs --no-providers" . >> "${DOCS_DIR}/${OUTS_MD}"
 
 }
 
@@ -51,11 +51,11 @@ function module_docs {
     if test -d ./modules; then
         for dir in ./modules/*; do
             mkdir -p "${dir}/${DOCS_DIR}"
-            
+
             echo -e "# Terraform Enterprise: Clustering\n" | tee "${dir}/${DOCS_DIR}/${INS_MD}" "${dir}/${DOCS_DIR}/${OUTS_MD}" &> /dev/null
 
-            eval "${BINARY_FILE} ${DOCS_CMDS} ${dir}/${VARS_TF}"  >> "${dir}/${DOCS_DIR}/${INS_MD}"
-            eval "${BINARY_FILE} ${DOCS_CMDS} ${dir}/${OUTS_TF}" >> "${dir}/${DOCS_DIR}/${OUTS_MD}"
+            eval "${BINARY_FILE} ${DOCS_CMDS} --no-outputs --no-providers ${dir}"  >> "${dir}/${DOCS_DIR}/${INS_MD}"
+            eval "${BINARY_FILE} ${DOCS_CMDS} --no-inputs --no-providers ${dir}" >> "${dir}/${DOCS_DIR}/${OUTS_MD}"
         done
     else
         echo "No modules directory, skipping."
@@ -66,6 +66,7 @@ function module_docs {
 setup
 main_docs
 module_docs
+
 
 
 

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -3,48 +3,52 @@
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| domain | An Azure hosted DNS domain to use for DNS records | string | n/a | yes |
-| key\_vault\_name | The name of an existing key vault to use for certificate generation. | string | n/a | yes |
-| license\_file | Path to the Replicated license file. | string | n/a | yes |
-| resource\_group\_name | An existing Azure Resource Group to deploy into. | string | n/a | yes |
-| subnet | An existing Azure Subnet to deploy into | string | n/a | yes |
-| tls\_pfx\_certificate | The path to a PFX certificate for front end SSL communication. | string | n/a | yes |
-| tls\_pfx\_certificate\_password | The password for the associated SSL certificate. | string | n/a | yes |
-| virtual\_network\_name | An existing Azure Virtual Network to deploy into | string | n/a | yes |
-| airgap\_installer\_url | URL to replicated's airgap installer package | string | `"https://install.terraform.io/installer/replicated-v5.tar.gz"` | no |
-| airgap\_mode\_enable | install in airgap mode | string | `"False"` | no |
-| airgap\_package\_url | Signed URL to download the package | string | `""` | no |
-| azure\_es\_account\_key | The Azure account key for external services | string | `""` | no |
-| azure\_es\_account\_name | The Azure account name for external services | string | `""` | no |
-| azure\_es\_container | The Azure container for external services | string | `""` | no |
-| ca\_bundle\_url | URL to Custom CA bundle used for outgoing connections | string | `""` | no |
-| distribution | Type of linux distribution to use. (ubuntu or rhel) | string | `"ubuntu"` | no |
-| dns\_ttl | The TTL for dns records. | string | `"120"` | no |
-| domain\_resource\_group\_name | The name of the resource group where the domain name resides, if not set the main resource group will be used. | string | `""` | no |
-| encryption\_password | The password for data encryption in non-external services modes. | string | `""` | no |
-| http\_proxy\_url | HTTP(S) Proxy URL | string | `""` | no |
-| iact\_subnet\_list | IP Cidr Mask to allow to access Initial Admin Creation Token (IACT) API. [Terraform Docs](https://www.terraform.io/docs/enterprise/private/automating-initial-user.html) | string | `""` | no |
-| iact\_subnet\_time\_limit | Amount of time to allow access to IACT API after initial boot | string | `""` | no |
-| import\_key | An additional ssh pub key to import to all machines | string | `""` | no |
-| installer\_url | URL to the cluster setup tool | string | `"https://install.terraform.io/installer/ptfe-0.1.zip"` | no |
-| key\_vault\_resource\_group\_name | The existing Azure Resource Group where the key vault is stored, defaults to the main resource group if not set. | string | `""` | no |
-| os\_disk\_size | The size in Gb for the OS disk of the primary seed virtual machine | string | `"100"` | no |
-| postgresql\_address | address to connect to external postgresql database at | string | `""` | no |
-| postgresql\_database | database name to use in exetrnal postgresql database | string | `""` | no |
-| postgresql\_extra\_params | additional connection string parameters (must be url query params) | string | `""` | no |
-| postgresql\_password | password to connect to external postgresql database as | string | `""` | no |
-| postgresql\_user | user to connect to external postgresql database as | string | `""` | no |
-| primary\_vm\_size | The Azure VM Size to use. | string | `"Standard_D4s_v3"` | no |
-| release\_sequence | The sequence ID for the Terraform Enterprise version to pin the cluster to. | string | `"latest"` | no |
-| repl\_cidr | Specify a non-standard CIDR range for the replicated services. The default is 10.96.0.0/12 | string | `""` | no |
-| resource\_prefix | Prefix name for resources created by this module | string | `"tfe"` | no |
-| secondary\_count | The number of secondary virtual machines to create. | string | `"5"` | no |
-| secondary\_vm\_size | The Azure VM Size to use (will use primary_vm_size if not set). | string | `""` | no |
-| ssh\_user | The ssh user to create | string | `"ubuntu"` | no |
-| storage\_image | A list of the data to define the os version image to build from | map | `{ "offer": "UbuntuServer", "publisher": "Canonical", "sku": "18.04-LTS", "version": "latest" }` | no |
-| tls\_pfx\_certificate\_key\_size | The size of the Key used in the Certificate. Possible values include 2048 and 4096. | string | `"2048"` | no |
-| tls\_pfx\_certificate\_key\_type | Specifies the Type of Key, such as RSA. | string | `"RSA"` | no |
-| vm\_size\_tier | The tier for the vms (must be 'Standard' or 'Basic') and must match with vm_size | string | `"Standard"` | no |
-| weave\_cidr | Specify a non-standard CIDR range for weave. The default is 10.32.0.0/12 | string | `""` | no |
+|------|-------------|------|---------|:-----:|
+| domain | An Azure hosted DNS domain to use for DNS records | `string` | n/a | yes |
+| key\_vault\_name | The name of an existing key vault to use for certificate generation. | `string` | n/a | yes |
+| license\_file | Path to the Replicated license file. | `string` | n/a | yes |
+| resource\_group\_name | An existing Azure Resource Group to deploy into. | `string` | n/a | yes |
+| subnet | An existing Azure Subnet to deploy into | `string` | n/a | yes |
+| tls\_pfx\_certificate | The path to a PFX certificate for front end SSL communication. | `string` | n/a | yes |
+| tls\_pfx\_certificate\_password | The password for the associated SSL certificate. | `string` | n/a | yes |
+| virtual\_network\_name | An existing Azure Virtual Network to deploy into | `string` | n/a | yes |
+| additional\_no\_proxy | Comma delimitted list of addresses (no spaces) to not use the proxy for | `string` | `""` | no |
+| additional\_tags | A map of additional tags to attach to all resources created. | `map` | `{}` | no |
+| airgap\_installer\_url | URL to replicated's airgap installer package | `string` | `"https://install.terraform.io/installer/replicated-v5.tar.gz"` | no |
+| airgap\_mode\_enable | install in airgap mode | `bool` | `false` | no |
+| airgap\_package\_url | Signed URL to download the package | `string` | `""` | no |
+| azure\_es\_account\_key | The Azure account key for external services | `string` | `""` | no |
+| azure\_es\_account\_name | The Azure account name for external services | `string` | `""` | no |
+| azure\_es\_container | The Azure container for external services | `string` | `""` | no |
+| ca\_bundle\_url | URL to Custom CA bundle used for outgoing connections | `string` | `""` | no |
+| distribution | Type of linux distribution to use. (ubuntu or rhel) | `string` | `"ubuntu"` | no |
+| dns\_ttl | The TTL for dns records. | `string` | `"120"` | no |
+| domain\_resource\_group\_name | The name of the resource group where the domain name resides, if not set the main resource group will be used. | `string` | `""` | no |
+| encryption\_password | The password for data encryption in non-external services modes. | `string` | `""` | no |
+| hostname | Hostname for loadbalancer frontend to use, otherwise will default to 'tfe-$install\_id.domain.com' | `string` | `""` | no |
+| http\_proxy\_url | HTTP(S) Proxy URL | `string` | `""` | no |
+| iact\_subnet\_list | List of IP Cidr Mask to allow to access Initial Admin Creation Token (IACT) API. [Terraform Docs](https://www.terraform.io/docs/enterprise/private/automating-initial-user.html) | `list(string)` | `[]` | no |
+| iact\_subnet\_time\_limit | Amount of time to allow access to IACT API after initial boot | `string` | `""` | no |
+| import\_key | An additional ssh pub key to import to all machines | `string` | `""` | no |
+| installer\_url | URL to the cluster setup tool | `string` | `"https://install.terraform.io/installer/ptfe-0.1.zip"` | no |
+| key\_vault\_resource\_group\_name | The existing Azure Resource Group where the key vault is stored, defaults to the main resource group if not set. | `string` | `""` | no |
+| os\_disk\_size | The size in Gb for the OS disk of the primary seed virtual machine | `string` | `"100"` | no |
+| postgresql\_address | address to connect to external postgresql database at | `string` | `""` | no |
+| postgresql\_database | database name to use in exetrnal postgresql database | `string` | `""` | no |
+| postgresql\_extra\_params | additional connection string parameters (must be url query params) | `string` | `""` | no |
+| postgresql\_password | password to connect to external postgresql database as | `string` | `""` | no |
+| postgresql\_user | user to connect to external postgresql database as | `string` | `""` | no |
+| primary\_vm\_size | The Azure VM Size to use. | `string` | `"Standard_D4s_v3"` | no |
+| release\_sequence | The sequence ID for the Terraform Enterprise version to pin the cluster to. | `string` | `"latest"` | no |
+| repl\_cidr | Specify a non-standard CIDR range for the replicated services. The default is 10.96.0.0/12 | `string` | `""` | no |
+| resource\_prefix | Prefix name for resources created by this module | `string` | `"tfe"` | no |
+| secondary\_count | The number of secondary virtual machines to create. | `number` | `5` | no |
+| secondary\_vm\_size | The Azure VM Size to use (will use primary\_vm\_size if not set). | `string` | `""` | no |
+| ssh\_user | The ssh user to create | `string` | `"ubuntu"` | no |
+| storage\_image | A list of the data to define the os version image to build from | <pre>object({<br>    publisher = string<br>    offer     = string<br>    sku       = string<br>    version   = string<br>  })</pre> | <pre>{<br>  "offer": "UbuntuServer",<br>  "publisher": "Canonical",<br>  "sku": "18.04-LTS",<br>  "version": "latest"<br>}</pre> | no |
+| tls\_pfx\_certificate\_key\_size | The size of the Key used in the Certificate. Possible values include 2048 and 4096. | `number` | `2048` | no |
+| tls\_pfx\_certificate\_key\_type | Specifies the Type of Key, such as RSA. | `string` | `"RSA"` | no |
+| virtual\_network\_resource\_group\_name | The existing Azure Resource Group where the virtual network resides, defaults to the main resource group if not set. | `string` | `""` | no |
+| vm\_size\_tier | The tier for the vms (must be 'Standard' or 'Basic') and must match with vm\_size | `string` | `"Standard"` | no |
+| weave\_cidr | Specify a non-standard CIDR range for weave. The default is 10.32.0.0/12 | `string` | `""` | no |
 

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -10,6 +10,6 @@
 | installer\_dashboard\_endpoint | The URI for accessing the backend console. |
 | installer\_dashboard\_password | Generated password to unlock the installer dashboard. |
 | primary\_public\_ip | The public IP address of the first primary node created. |
-| ssh\_config\_file | Path to ssh_config file for command: `ssh -F $(terraform state show <terraform_parent_modules>.module.<module_name>.module.primaries.local_file.ssh_config | grep filename | awk '{print $3}') default` |
+| ssh\_config\_file | Path to ssh\_config file for command: `ssh -F $(terraform state show <terraform_parent_modules>.module.<module_name>.module.primaries.local_file.ssh_config \| grep filename \| awk '{print $3}') default` |
 | ssh\_private\_key | Path to the private key used for ssh authorization. |
 

--- a/modules/cluster_lb/docs/inputs.md
+++ b/modules/cluster_lb/docs/inputs.md
@@ -3,13 +3,15 @@
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| dns | Expects keys: [domain, rg_name, ttl] | map | n/a | yes |
-| install\_id | A prefix to use for resource names | string | n/a | yes |
-| lb\_port | Expects map with format `name: [frontend_port, protocol, backend_port]` for all routes. | map | n/a | yes |
-| location | The Azure Location to build into | string | n/a | yes |
-| resource\_prefix | Prefix name for resources | string | n/a | yes |
-| rg\_name | The Azure Resource Group to build into | string | n/a | yes |
-| lb\_probe\_interval | The interval for the Loadbalancer healthcheck probe. | string | `"10"` | no |
-| lb\_probe\_unhealthy\_threshold | The amount of unhealthy checks before marking a node unhealthy. | string | `"2"` | no |
+|------|-------------|------|---------|:-----:|
+| dns | Expects keys: [domain, rg\_name, ttl] | <pre>object({<br>    domain  = string<br>    rg_name = string<br>    ttl     = number<br>  })</pre> | n/a | yes |
+| install\_id | A prefix to use for resource names | `string` | n/a | yes |
+| lb\_port | Expects map with format `name: [frontend_port, protocol, backend_port]` for all routes. | `map(list(string))` | n/a | yes |
+| location | The Azure Location to build into | `string` | n/a | yes |
+| resource\_prefix | Prefix name for resources | `string` | n/a | yes |
+| rg\_name | The Azure Resource Group to build into | `string` | n/a | yes |
+| additional\_tags | A map of additional tags to attach to all resources created. | `map` | `{}` | no |
+| hostname | hostname for loadbalancer front end to use | `string` | `""` | no |
+| lb\_probe\_interval | The interval for the Loadbalancer healthcheck probe. | `number` | `10` | no |
+| lb\_probe\_unhealthy\_threshold | The amount of unhealthy checks before marking a node unhealthy. | `number` | `2` | no |
 

--- a/modules/common/docs/inputs.md
+++ b/modules/common/docs/inputs.md
@@ -3,15 +3,16 @@
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| dns | Expects key: [rg_name] | map | n/a | yes |
-| install\_id | A prefix to use for resource names | string | n/a | yes |
-| key\_size | Byte size for the key-pair used to generate the provided certificate | string | n/a | yes |
-| key\_type | Type of key-pair used to generate the provided certificate | string | n/a | yes |
-| key\_vault | Expects keys: [name, rg_name] (key_vault name and Azure resource group that key vault resides in.) | map | n/a | yes |
-| resource\_prefix | Prefix name for resources | string | n/a | yes |
-| rg\_name | The Azure Resource Group to build into | string | n/a | yes |
-| subnet\_name | The Azure Virtual Network Subnet to build into | string | n/a | yes |
-| tls | Expects keys: [pfx_cert, pfx_cert_pw] (the path to a pfx certificate for the dns zone, the password for that certificate) | map | n/a | yes |
-| vnet\_name | The Azure Virtual Network to build into | string | n/a | yes |
+|------|-------------|------|---------|:-----:|
+| install\_id | A prefix to use for resource names | `string` | n/a | yes |
+| key\_size | Byte size for the key-pair used to generate the provided certificate | `string` | n/a | yes |
+| key\_type | Type of key-pair used to generate the provided certificate | `string` | n/a | yes |
+| key\_vault | Expects keys: [name, rg\_name] (key\_vault name and Azure resource group that key vault resides in.) | <pre>object({<br>    name    = string<br>    rg_name = string<br>  })</pre> | n/a | yes |
+| resource\_prefix | Prefix name for resources | `string` | n/a | yes |
+| rg\_name | The Azure Resource Group to build into | `string` | n/a | yes |
+| subnet\_name | The Azure Virtual Network Subnet to build into | `string` | n/a | yes |
+| tls | Expects keys: [pfx\_cert, pfx\_cert\_pw] (the path to a pfx certificate for the dns zone, the password for that certificate) | <pre>object({<br>    pfx_cert    = string<br>    pfx_cert_pw = string<br>  })</pre> | n/a | yes |
+| vnet | Expects keys: [name, rg\_name] (The Azure Virtual Network to build into and the resource group of the Virtual Network | <pre>object({<br>    name    = string<br>    rg_name = string<br>  })</pre> | n/a | yes |
+| additional\_tags | A map of additional tags to attach to all resources created. | `map` | `{}` | no |
+| domain\_rg\_name | Resource group of the DNS zone | `string` | `""` | no |
 

--- a/modules/configs/docs/inputs.md
+++ b/modules/configs/docs/inputs.md
@@ -3,24 +3,27 @@
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| airgap | Expects keys: [enable, package_url, installer_url] | map | n/a | yes |
-| assistant\_port | Port the assitant sidecar-like node service is running on. | string | n/a | yes |
-| azure\_es | Expects keys: [enable, account_name, account_key, container] | map | n/a | yes |
-| ca\_bundle\_url | URL to CA certificate file used for the internal `ptfe-proxy` used for outgoing connections | string | n/a | yes |
-| cert\_thumbprint | The thumbprint for the Azure Key Vault Certificate object generated from the provided PFX certificate. | string | n/a | yes |
-| cluster\_api\_endpoint | URI to the cluster api | string | n/a | yes |
-| cluster\_endpoint | URI to the cluster | string | n/a | yes |
-| distribution | Type of linux distribution to use. (ubuntu or rhel) | string | n/a | yes |
-| encryption\_password | The password for data encryption in non-external services modes. | string | n/a | yes |
-| http\_proxy\_url | HTTP(S) Proxy URL | string | n/a | yes |
-| iact | Expects keys: [subnet_list, subnet_time_limit] | map | n/a | yes |
-| import\_key | An additional ssh pub key to import to all machines | string | n/a | yes |
-| installer\_url | URL to the cluster installer tool | string | n/a | yes |
-| license\_file | Path to license file for the application | string | n/a | yes |
-| postgresql | Expects keys: [user, password, address, database, extra_params] | map | n/a | yes |
-| primary\_count | The count of primary instances being created. | string | n/a | yes |
-| release\_sequence | The sequence ID for the Terraform Enterprise version to pin the cluster to. | string | n/a | yes |
-| repl\_cidr | custom replicated service CIDR range | string | n/a | yes |
-| weave\_cidr | custom weave CIDR range | string | n/a | yes |
+|------|-------------|------|---------|:-----:|
+| airgap | Expects keys: [enable, package\_url, installer\_url] | <pre>object({<br>    enable        = bool<br>    package_url   = string<br>    installer_url = string<br>  })</pre> | n/a | yes |
+| assistant\_port | Port the assitant sidecar-like node service is running on. | `any` | n/a | yes |
+| azure\_es | Expects keys: [enable, account\_name, account\_key, container] | <pre>object({<br>    enable       = bool<br>    account_name = string<br>    account_key  = string<br>    container    = string<br>  })</pre> | n/a | yes |
+| ca\_bundle\_url | URL to CA certificate file used for the internal `ptfe-proxy` used for outgoing connections | `string` | n/a | yes |
+| cert\_thumbprint | The thumbprint for the Azure Key Vault Certificate object generated from the provided PFX certificate. | `string` | n/a | yes |
+| cluster\_api\_endpoint | URI to the cluster api | `string` | n/a | yes |
+| cluster\_endpoint | URI to the cluster | `string` | n/a | yes |
+| cluster\_hostname | The hostname of the TFE application. Example: tfe.company.com | `string` | n/a | yes |
+| distribution | Type of linux distribution to use. (ubuntu or rhel) | `string` | n/a | yes |
+| encryption\_password | The password for data encryption in non-external services modes. | `string` | n/a | yes |
+| http\_proxy\_url | HTTP(S) Proxy URL | `string` | n/a | yes |
+| iact | Expects keys: [subnet\_list, subnet\_time\_limit] | <pre>object({<br>    subnet_list       = list(string)<br>    subnet_time_limit = string<br>  })</pre> | n/a | yes |
+| import\_key | An additional ssh pub key to import to all machines | `string` | n/a | yes |
+| installer\_url | URL to the cluster installer tool | `string` | n/a | yes |
+| license\_file | Path to license file for the application | `string` | n/a | yes |
+| postgresql | Expects keys: [user, password, address, database, extra\_params] | <pre>object({<br>    user         = string<br>    password     = string<br>    address      = string<br>    database     = string<br>    extra_params = string<br>  })</pre> | n/a | yes |
+| primary\_count | The count of primary instances being created. | `number` | n/a | yes |
+| release\_sequence | The sequence ID for the Terraform Enterprise version to pin the cluster to. | `string` | n/a | yes |
+| repl\_cidr | custom replicated service CIDR range | `string` | n/a | yes |
+| weave\_cidr | custom weave CIDR range | `string` | n/a | yes |
+| additional\_no\_proxy | Comma delimitted list of addresses (no spaces) to not use the proxy for | `string` | `""` | no |
+| additional\_tags | A map of additional tags to attach to all resources created. | `map` | `{}` | no |
 

--- a/modules/primaries/docs/inputs.md
+++ b/modules/primaries/docs/inputs.md
@@ -3,19 +3,20 @@
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| cloud\_init\_data\_list | List of rendered cloud-init templates to pass to the vms. | list | n/a | yes |
-| cluster\_backend\_pool\_id | The id of the backend pool for the cluster loadbalancer. | string | n/a | yes |
-| external\_services | Boolean string for whether or not to install in Internal Production Mode or External Services Mode | string | n/a | yes |
-| install\_id | A prefix to use for resource names | string | n/a | yes |
-| key\_vault | Expects keys: [id, cert_uri] | map | n/a | yes |
-| location | The Azure Location to build into | string | n/a | yes |
-| os\_disk\_size | Specifies the size of the OS Disk in gigabytes. | string | n/a | yes |
-| resource\_prefix | Prefix name for resources | string | n/a | yes |
-| rg\_name | The Azure Resource Group to build into | string | n/a | yes |
-| ssh | Expects keys: [public_key, private_key_path] | map | n/a | yes |
-| storage\_image | Expects keys: [publisher, offer, sku, version] | map | n/a | yes |
-| subnet\_id | The Azure Subnet to build into | string | n/a | yes |
-| username | Specifies the name of the local administrator account. | string | n/a | yes |
-| vm | Expects keys: [count, size] | map | n/a | yes |
+|------|-------------|------|---------|:-----:|
+| cloud\_init\_data\_list | List of rendered cloud-init templates to pass to the vms. | `list(string)` | n/a | yes |
+| cluster\_backend\_pool\_id | The id of the backend pool for the cluster loadbalancer. | `string` | n/a | yes |
+| external\_services | Boolean string for whether or not to install in Internal Production Mode or External Services Mode | `string` | n/a | yes |
+| install\_id | A prefix to use for resource names | `string` | n/a | yes |
+| key\_vault | Expects keys: [id, cert\_uri] | <pre>object({<br>    id       = string<br>    cert_uri = string<br>  })</pre> | n/a | yes |
+| location | The Azure Location to build into | `string` | n/a | yes |
+| os\_disk\_size | Specifies the size of the OS Disk in gigabytes. | `string` | n/a | yes |
+| resource\_prefix | Prefix name for resources | `string` | n/a | yes |
+| rg\_name | The Azure Resource Group to build into | `string` | n/a | yes |
+| ssh | Expects keys: [public\_key, private\_key\_path] | <pre>object({<br>    public_key       = string<br>    private_key_path = string<br>  })</pre> | n/a | yes |
+| storage\_image | Expects keys: [publisher, offer, sku, version] | <pre>object({<br>    publisher = string<br>    offer     = string<br>    sku       = string<br>    version   = string<br>  })</pre> | n/a | yes |
+| subnet\_id | The Azure Subnet to build into | `string` | n/a | yes |
+| username | Specifies the name of the local administrator account. | `string` | n/a | yes |
+| vm | Expects keys: [count, size] | <pre>object({<br>    count = number<br>    size  = string<br>  })</pre> | n/a | yes |
+| additional\_tags | A map of additional tags to attach to all resources created. | `map` | `{}` | no |
 

--- a/modules/primaries/docs/outputs.md
+++ b/modules/primaries/docs/outputs.md
@@ -7,5 +7,5 @@
 | ip\_conf\_name | The name of the IP Configuration object for the Azure Network Interfaces for the primary vms. |
 | network\_interfaces | List of ids of Azure Network Interface objects tied to the primary vms. |
 | public\_ips | List of public ips for the nodes. |
-| ssh\_config\_path | Path to the generated ssh_config file |
+| ssh\_config\_path | Path to the generated ssh\_config file |
 

--- a/modules/secondaries/docs/inputs.md
+++ b/modules/secondaries/docs/inputs.md
@@ -3,15 +3,16 @@
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| cloud\_init\_data | Rendered cloud-init template to pass to the vms. | string | n/a | yes |
-| install\_id | A prefix to use for resource names | string | n/a | yes |
-| location | The Azure Location to build into | string | n/a | yes |
-| resource\_prefix | Prefix name for resources | string | n/a | yes |
-| rg\_name | The Azure Resource Group to build into | string | n/a | yes |
-| ssh\_public\_key | The ssh public key to give to all vms in the scale-set for the local administrator account. | string | n/a | yes |
-| storage\_image | Expects keys: [publisher, offer, sku, version] | map | n/a | yes |
-| subnet\_id | The Azure Subnet to build into | string | n/a | yes |
-| username | Specifies the name of the local administrator account. | string | n/a | yes |
-| vm | Expects keys: [size, count, size_tier] | map | n/a | yes |
+|------|-------------|------|---------|:-----:|
+| cloud\_init\_data | Rendered cloud-init template to pass to the vms. | `string` | n/a | yes |
+| install\_id | A prefix to use for resource names | `string` | n/a | yes |
+| location | The Azure Location to build into | `string` | n/a | yes |
+| resource\_prefix | Prefix name for resources | `string` | n/a | yes |
+| rg\_name | The Azure Resource Group to build into | `string` | n/a | yes |
+| ssh\_public\_key | The ssh public key to give to all vms in the scale-set for the local administrator account. | `string` | n/a | yes |
+| storage\_image | Expects keys: [publisher, offer, sku, version] | <pre>object({<br>    publisher = string<br>    offer     = string<br>    sku       = string<br>    version   = string<br>  })</pre> | n/a | yes |
+| subnet\_id | The Azure Subnet to build into | `string` | n/a | yes |
+| username | Specifies the name of the local administrator account. | `string` | n/a | yes |
+| vm | Expects keys: [size, count, size\_tier] | <pre>object({<br>    count     = number<br>    size      = string<br>    size_tier = string<br>  })</pre> | n/a | yes |
+| additional\_tags | A map of additional tags to attach to all resources created. | `map` | `{}` | no |
 

--- a/modules/secondaries/docs/outputs.md
+++ b/modules/secondaries/docs/outputs.md
@@ -1,3 +1,6 @@
 # Terraform Enterprise: Clustering
 
+## Outputs
+
+No output.
 


### PR DESCRIPTION
## Background

Azure version of what I did over in https://github.com/hashicorp/terraform-aws-terraform-enterprise/pull/67 .

Too link didn't click; This script updates the doc-gen.sh script with a newer binary and updates the flags to match as the older one was breaking. Then I ran the script to generate new docs for the modules to make sure inputs/outputs were up to date. 

## How Has This Been Tested

Ran `.scripts/doc-gen.sh` and here we are! 

## This PR makes me feel

![Creepy, maybe sleepy, snail in trance flipping through books](https://media.giphy.com/media/lc5bgm7ML3TeE/giphy.gif)
