### PR TITLE
Assign user assigned identity to VMSS

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -389,14 +389,16 @@ module "vm" {
   location                    = var.location
 
   # VM
-  vm_sku                  = var.vm_sku
-  vm_image_id             = var.vm_image_id
-  vm_os_disk_disk_size_gb = var.vm_os_disk_disk_size_gb
-  vm_subnet_id            = local.network_private_subnet_id
-  vm_user                 = var.vm_user
-  vm_public_key           = var.vm_public_key == "" ? tls_private_key.tfe_ssh[0].public_key_openssh : var.vm_public_key
-  vm_userdata_script      = module.user_data.tfe_userdata_base64_encoded
-  vm_node_count           = var.vm_node_count
+  vm_sku                                 = var.vm_sku
+  vm_image_id                            = var.vm_image_id
+  vm_os_disk_disk_size_gb                = var.vm_os_disk_disk_size_gb
+  vm_subnet_id                           = local.network_private_subnet_id
+  vm_user                                = var.vm_user
+  vm_public_key                          = var.vm_public_key == "" ? tls_private_key.tfe_ssh[0].public_key_openssh : var.vm_public_key
+  vm_userdata_script                     = module.user_data.tfe_userdata_base64_encoded
+  vm_node_count                          = var.vm_node_count
+  vm_user_assigned_identity_id           = module.service_accounts.vmss_user_assigned_identity.id
+  vm_user_assigned_identity_principal_id = module.service_accounts.vmss_user_assigned_identity.principal_id
 
   # Load balancer
   load_balancer_type       = var.load_balancer_type

--- a/modules/service_accounts/main.tf
+++ b/modules/service_accounts/main.tf
@@ -44,3 +44,11 @@ resource "azurerm_storage_account" "bootstrap_storage_account" {
 
   tags = var.tags
 }
+
+resource "azurerm_user_assigned_identity" "vmss" {
+  location            = var.location
+  name                = "${var.friendly_name_prefix}-vmss"
+  resource_group_name = var.resource_group_name
+
+  tags = var.tags
+}

--- a/modules/service_accounts/outputs.tf
+++ b/modules/service_accounts/outputs.tf
@@ -13,3 +13,9 @@ output "storage_account_primary_blob_connection_string" {
 output "bootstrap_storage_account_name" {
   value = local.bootstrap_storage_account_name
 }
+
+output "vmss_user_assigned_identity" {
+  value = azurerm_user_assigned_identity.vmss
+
+  description = "The user assigned identity to be assigned to the virtual machine scale set."
+}

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -16,7 +16,9 @@ resource "azurerm_linux_virtual_machine_scale_set" "tfe_vmss" {
   custom_data = var.vm_userdata_script
 
   identity {
-    type = "SystemAssigned"
+    type = "UserAssigned"
+
+    identity_ids = [var.vm_user_assigned_identity_id]
   }
 
   # Source image id will be used if vm_image_id anything other than 'ubuntu' or 'rhel'
@@ -72,7 +74,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "tfe_vmss" {
 resource "azurerm_role_assignment" "tfe_vmss_role_assignment" {
   scope                = var.resource_group_id_bootstrap
   role_definition_name = "Storage Blob Data Reader"
-  principal_id         = azurerm_linux_virtual_machine_scale_set.tfe_vmss.identity[0].principal_id
+  principal_id         = var.vm_user_assigned_identity_principal_id
 }
 
 resource "azurerm_virtual_machine_scale_set_extension" "main" {

--- a/modules/vm/variables.tf
+++ b/modules/vm/variables.tf
@@ -101,6 +101,18 @@ variable "vm_image_id" {
   }
 }
 
+variable "vm_user_assigned_identity_id" {
+  description = "The identity of the user assigned identity to be assigned to the virtual machine scale set."
+  type        = string
+}
+
+variable "vm_user_assigned_identity_principal_id" {
+  description = <<EOD
+  The Service Principal identity of the user assigned identity to be assigned to the virtual machine scale set.
+  EOD
+  type        = string
+}
+
 # Optional variables not currently specified in root module
 variable "vm_overprovision" {
   default = false


### PR DESCRIPTION
## Background

#92 reported that there is a race condition between `azurerm_role_assignment.tfe_vmss_role_assignment` being created and the VM initialization script attempting to download the license. While #93 proposed to fix that issue by adding polling logic to the license download command, this branch attempts to solve the issue by introducing  `azurerm_user_assigned_identity.vmss` and removing the dependency of `azurerm_role_assignment.tfe_vmss_role_assignment` on `azurerm_linux_virtual_machine_scale_set.tfe_vmss`. This change should allow the identity assigned to the virtual machine scale set to be sufficiently authorized to download the license before any virtual machines begin to initialize.

## How Has This Been Tested

This was verified by @josh-barker in #92.

### Test Configuration

* Terraform Version: 0.14.9

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media2.giphy.com/media/lIg15wzqRGX6w/200.gif?cid=5a38a5a27ngmmqbtfn5e3a9hchbop0w33sdz1bkebzz6zpeo&rid=200.gif&ct=g)
