### PR TITLE
fix: move key vault policy to separate resource so policies are stable

### DIFF
--- a/modules/certificates/main.tf
+++ b/modules/certificates/main.tf
@@ -91,56 +91,59 @@ resource "azurerm_key_vault" "kv" {
   enabled_for_deployment      = var.enabled_for_deployment
   enabled_for_disk_encryption = var.enabled_for_disk_encryption
 
-  access_policy {
-    tenant_id = var.tenant_id
-    object_id = var.object_id
-
-    certificate_permissions = [
-      "create",
-      "delete",
-      "get",
-      "import",
-      "list",
-      "listissuers",
-      "managecontacts",
-      "manageissuers",
-      "purge",
-      "setissuers",
-      "update",
-    ]
-
-    key_permissions = [
-      "backup",
-      "create",
-      "decrypt",
-      "delete",
-      "encrypt",
-      "get",
-      "import",
-      "list",
-      "purge",
-      "recover",
-      "restore",
-      "sign",
-      "unwrapKey",
-      "update",
-      "verify",
-      "wrapKey",
-    ]
-
-    secret_permissions = [
-      "backup",
-      "delete",
-      "get",
-      "list",
-      "purge",
-      "recover",
-      "restore",
-      "set",
-    ]
-  }
-
   tags = var.tags
+}
+
+resource "azurerm_key_vault_access_policy" "tfe_kv_acl" {
+  count = var.key_vault_name == "" && var.load_balancer_type == "application_gateway" ? 1 : 0
+
+  key_vault_id = azurerm_key_vault.kv[0].id
+  tenant_id    = var.tenant_id
+  object_id    = var.object_id
+
+  certificate_permissions = [
+    "create",
+    "delete",
+    "get",
+    "import",
+    "list",
+    "listissuers",
+    "managecontacts",
+    "manageissuers",
+    "purge",
+    "setissuers",
+    "update",
+  ]
+
+  key_permissions = [
+    "backup",
+    "create",
+    "decrypt",
+    "delete",
+    "encrypt",
+    "get",
+    "import",
+    "list",
+    "purge",
+    "recover",
+    "restore",
+    "sign",
+    "unwrapKey",
+    "update",
+    "verify",
+    "wrapKey",
+  ]
+
+  secret_permissions = [
+    "backup",
+    "delete",
+    "get",
+    "list",
+    "purge",
+    "recover",
+    "restore",
+    "set",
+  ]
 }
 
 # Azure Key Vault Certificate


### PR DESCRIPTION
## Background

When using the active active example, the key vault policies are created and destroyed because:

1. A policy is created inside the key vault in the certificates module. See [here](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/blob/master/modules/certificates/main.tf#L94)
2. A policy is created in load balancer module. See [here](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/blob/master/modules/load_balancer/main.tf#L63)

Initially, both policies are created.
On the next apply, the `key_vault` resource removes the policy from the load balancer module.
On the next apply, the load balancer module creates the policy.
And so on.


## How Has This Been Tested

```bash
terraform init
terraform apply
terraform apply
```

### Test Configuration

* Terraform Version: 0.13.7
