### PR TITLE
removing unused var in private-active-active test

### DIFF
--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -30,7 +30,6 @@ module "private_active_active" {
   # Behind proxy information
   proxy_ip               = azurerm_linux_virtual_machine.proxy.private_ip_address
   proxy_port             = local.proxy_port
-  proxy_cert_secret_name = var.proxy_cert_secret_name
 
   # Private Active / Active Scenario
   vm_node_count               = 2

--- a/tests/private-active-active/variables.tf
+++ b/tests/private-active-active/variables.tf
@@ -38,11 +38,6 @@ variable "certificate_name" {
   description = "Azure Key Vault Certificate name for Application Gateway"
 }
 
-variable "proxy_cert_secret_name" {
-  type        = string
-  description = "Name of the secret under which the proxy cert is stored in the Azure Key Vault."
-}
-
 # Bootstrap Resources Storage Account
 # -----------------------------------
 


### PR DESCRIPTION
## Background

As I was working on [this task](https://app.asana.com/0/0/1200556893411050/f) to create all of the secrets for the tests, I realized that the `private-active-active` had a variable for the `proxy_cert_secret_name` that it wasn't using, so this removes it.

## How Has This Been Tested

Tested it locally just to be sure it wasn't using it somewhere that I missed. It worked.

## This PR makes me feel

![missed it](https://media.giphy.com/media/jPG4Fc50XQTVHhlzwP/giphy.gif)
