### PR TITLE
update destroy command output

### DIFF
--- a/.github/workflows/handler-destroy.yml
+++ b/.github/workflows/handler-destroy.yml
@@ -55,14 +55,10 @@ jobs:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           body: |
-            :computer: @hc-team-tfe
+            ${{ format('### {0} Terraform Public Active/Active Destruction Report', job.status == 'success' && ':white_check_mark:' || ':x:') }}
 
-            ### Terraform Public Active/Active Destruction Report :newspaper:
+            ${{ format(':link: [Action Summary Page]({0})', steps.vars.outputs.run-url) }}
 
-            - `${{ steps.init.outcome }}` Terraform Initialization :gear: 
+            ${{ format('- {0} Terraform Init', steps.init.outcome == 'success' && ':white_check_mark:' || ':x:') }}
 
-            - `${{ steps.destroy.outcome }}` Terraform Destroy :fire:
-
-            :link: [Action Summary Page][1]
-
-            [1]: ${{ steps.vars.outputs.run-url }}
+            ${{ format('- {0} Terraform Destroy', steps.destroy.outcome == 'success' && ':white_check_mark:' || ':x:') }}


### PR DESCRIPTION
## Background

This branch updates the `/destroy public-active-active` command with the output that uses ✅  and ❌.

[Asana Task](https://app.asana.com/0/1181500399442529/1200423085269891/f)

## How Has This Been Tested

It has not, but it uses the same [code](https://github.com/hashicorp/terraform-google-terraform-enterprise/blob/main/.github/workflows/handler-destroy.yml#L58-L64) as the GCP module.

## This PR makes me feel

![clear output](https://media.giphy.com/media/517eQCwqG2Z44ckIhU/giphy.gif)
