### PR TITLE
Write GHA IP to network_allow_range

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -248,6 +248,11 @@ jobs:
         working-directory: ${{ env.WORK_DIR_PATH }}
         run: terraform validate -no-color
 
+      - name: Write GitHub Actions runner CIDR to Terraform Variables
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          echo "network_allow_range = \"$( dig +short @resolver1.opendns.com myip.opendns.com )/32\"" > github.auto.tfvars
+
       - name: Terraform Apply
         id: apply
         working-directory: ${{ env.WORK_DIR_PATH }}


### PR DESCRIPTION


## Background

This branch passes the GitHub Actions runner IP address to private-active-active in order to facilitate access to the bastion host.




## How Has This Been Tested

To be tested in #117.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media4.giphy.com/media/l2JdY4MYyJYUS6JLW/giphy.gif?cid=5a38a5a23t3a0qsoo3hcyj2pyjakd00zaprcupz82w7k5b9h&rid=giphy.gif&ct=g)
