### PR TITLE
Fix reference to bastion_fqdn output name

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -268,7 +268,7 @@ jobs:
         id: retrieve-bastion-fqdn
         working-directory: ${{ env.WORK_DIR_PATH }}
         run: |
-          terraform output -no-color -raw proxy_instance_name
+          terraform output -no-color -raw bastion_fqdn
 
       - name: Write Private SSH Key
         env:


### PR DESCRIPTION


## Background

This branch fixes the output name used in the Retrieve Bastion FQDN step of the private-active-active job.

## How Has This Been Tested

To be tested in #117.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media2.giphy.com/media/xULW8vi25RrpxQrmrm/200.gif?cid=5a38a5a23qfpyclvz86qn0tkfisiluqwyd1g9r2y7oifbl9o&rid=200.gif&ct=g)
