### PR TITLE
hardcode most standalone-poc variables

### DIFF
--- a/tests/standalone-poc/data.tf
+++ b/tests/standalone-poc/data.tf
@@ -1,14 +1,14 @@
 data "azurerm_key_vault_certificate" "load_balancer" {
-  name         = var.load_balancer_certificate_name
+  name         = "wildcard"
   key_vault_id = var.key_vault_id
 }
 
 data "azurerm_key_vault_secret" "vm_certificate" {
-  name         = var.vm_certificate_secret_name
+  name         = "wildcard-chained-certificate-pem"
   key_vault_id = var.key_vault_id
 }
 
 data "azurerm_key_vault_secret" "vm_key" {
-  name         = var.vm_key_secret_name
+  name         = "wildcard-private-key-pem"
   key_vault_id = var.key_vault_id
 }

--- a/tests/standalone-poc/main.tf
+++ b/tests/standalone-poc/main.tf
@@ -7,17 +7,17 @@ resource "random_string" "friendly_name" {
 
 resource "azurerm_key_vault_secret" "tfe_license" {
   name         = "tfe-license-${local.friendly_name_prefix}"
-  value        = filebase64(var.tfe_license_path)
+  value        = filebase64(var.license_file)
   key_vault_id = var.key_vault_id
 }
 
 module "standalone_poc" {
   source = "../../"
 
-  domain_name             = var.domain_name
+  domain_name             = "team-private-terraform-enterprise.azure.ptfedev.com"
   friendly_name_prefix    = local.friendly_name_prefix
-  location                = var.location
-  resource_group_name_dns = var.resource_group_name_dns
+  location                = "Central US"
+  resource_group_name_dns = "ptfeacc-rg"
 
   # Bootstrapping resources
   load_balancer_certificate = data.azurerm_key_vault_certificate.load_balancer

--- a/tests/standalone-poc/variables.tf
+++ b/tests/standalone-poc/variables.tf
@@ -1,52 +1,8 @@
-# General
-# -------
-variable "location" {
-  type        = string
-  description = "Azure location name e.g. East US"
-}
-
-# Domain
-# ------
-variable "domain_name" {
-  type        = string
-  description = "Domain to create Terraform Enterprise subdomain within"
-}
-
-variable "resource_group_name_dns" {
-  type        = string
-  description = "Name of resource group which contains desired DNS zone"
-}
-
-# Key Vault and Certificate
-# -------------------------
-variable "load_balancer_certificate_name" {
-  type        = string
-  description = "The name of a Key Vault certificate which will be attached to the application gateway."
-}
-
 variable "key_vault_id" {
   type        = string
   description = "The identity of the Key Vault which contains secrets and certificates."
 }
 
-variable "vm_certificate_secret_name" {
-  type        = string
-  description = <<-EOD
-  The name of a Key Vault secret which contains the Base64 encoded version of a PEM encoded public certificate of a
-  certificate authority (CA) to be trusted by the Virtual Machine Scale Set.
-  EOD
-}
-
-variable "vm_key_secret_name" {
-  type        = string
-  description = <<-EOD
-  The name of a Key Vault secret which contains the Base64 encoded version of a PEM encoded private key of a
-  certificate authority (CA) to be trusted by the Virtual Machine Scale Set.
-  EOD
-}
-
-# User Data
-# ---------
 variable "iact_subnet_list" {
   default     = []
   description = <<-EOD
@@ -56,7 +12,7 @@ variable "iact_subnet_list" {
   type        = list(string)
 }
 
-variable "tfe_license_path" {
+variable "license_file" {
   type        = string
   description = "The local path to the Terraform Enterprise license to be provided by CI."
 }


### PR DESCRIPTION
## Background

[Asana Task](https://app.asana.com/0/1181500399442529/1201068889880676/f)

In an effort to pare down the number of variables that need to be populated by the automation that is running the `standalone-poc` test, this branch hardcodes those variables that are safe for a public audience.

## How Has This Been Tested

I ran the `standalone-poc` module locally and destroyed it successfully.
 
## This PR makes me feel

![there are so many variables](https://media.giphy.com/media/h40jcPnWq7x5buK6Am/giphy.gif)
