### PR TITLE
add scale_in_policy to vmss

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -301,6 +301,7 @@ module "vm" {
   vm_public_key           = var.vm_public_key == null ? tls_private_key.tfe_ssh[0].public_key_openssh : var.vm_public_key
   vm_userdata_script      = module.user_data.tfe_userdata_base64_encoded
   vm_node_count           = var.vm_node_count
+  vm_vmss_scale_in_policy = var.vm_vmss_scale_in_policy
 
   # Load balancer
   load_balancer_type       = var.load_balancer_type

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -30,10 +30,11 @@ resource "azurerm_linux_virtual_machine_scale_set" "tfe_vmss" {
   location            = var.location
   resource_group_name = var.resource_group_name
 
-  overprovision  = var.vm_overprovision
-  instances      = var.vm_node_count
-  sku            = var.vm_sku
-  admin_username = var.vm_user
+  overprovision   = var.vm_overprovision
+  instances       = var.vm_node_count
+  sku             = var.vm_sku
+  admin_username  = var.vm_user
+  scale_in_policy = var.vm_vmss_scale_in_policy
 
   upgrade_mode = var.vm_upgrade_mode
 

--- a/modules/vm/variables.tf
+++ b/modules/vm/variables.tf
@@ -104,6 +104,21 @@ variable "vm_image_id" {
   }
 }
 
+variable "vm_vmss_scale_in_policy" {
+  description = "The scale-in policy to use for the virtual machine scale set."
+  type        = string
+
+  validation {
+    condition = (
+      var.vm_vmss_scale_in_policy == "Default" ||
+      var.vm_vmss_scale_in_policy == "NewestVM" ||
+      var.vm_vmss_scale_in_policy == "OldestVM"
+    )
+
+    error_message = "The vm_vmss_scale_in_policy value must be 'Default', 'NewestVM', or 'OldestVM'."
+  }
+}
+
 variable "ca_certificate_secret" {
   type = object({
     key_vault_id = string

--- a/variables.tf
+++ b/variables.tf
@@ -412,6 +412,22 @@ variable "vm_os_disk_disk_size_gb" {
   description = "The size of the Data Disk which should be created"
 }
 
+variable "vm_vmss_scale_in_policy" {
+  default     = "Default"
+  type        = string
+  description = "The scale-in policy to use for the virtual machine scale set."
+
+  validation {
+    condition = (
+      var.vm_vmss_scale_in_policy == "Default" ||
+      var.vm_vmss_scale_in_policy == "NewestVM" ||
+      var.vm_vmss_scale_in_policy == "OldestVM"
+    )
+
+    error_message = "The vm_vmss_scale_in_policy value must be 'Default', 'NewestVM', or 'OldestVM'."
+  }
+}
+
 # User Data
 # ---------
 variable "user_data_installation_type" {


### PR DESCRIPTION
## Background

[Asana Task](https://app.asana.com/0/1181500399442529/1201453873600460/f)

This branch adds the argument and variable for [scale_in_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine_scale_set#scale_in_policy) on the virtual machine scale set which will decide which virtual machines are chosen for removal when a Virtual Machine Scale Set is scaled in.

## How Has This Been Tested

Will be tested here.

## This PR makes me feel

![which one goes first](https://media.giphy.com/media/Wx8qG54ZvkDPYofCzW/giphy.gif)
