### PR TITLE
Make App Gateway depend on Key Vault access policy

### DIFF
--- a/modules/load_balancer/main.tf
+++ b/modules/load_balancer/main.tf
@@ -114,6 +114,13 @@ resource "azurerm_key_vault_access_policy" "tfe_kv_acl" {
 resource "azurerm_application_gateway" "tfe_ag" {
   count = var.load_balancer_type == "application_gateway" ? 1 : 0
 
+  depends_on = [
+    # This explicit dependency is required to ensure that the access policy is created before the application gateway.
+    # It is not possible to use the the object ID of the access policy as the identity ID of the application gateway
+    # as they are required to be different values of the user assigned identity (principal ID versus ID).
+    azurerm_key_vault_access_policy.tfe_kv_acl
+  ]
+
   name                = "${var.friendly_name_prefix}-ag"
   resource_group_name = var.resource_group_name
   location            = var.location

--- a/modules/load_balancer/main.tf
+++ b/modules/load_balancer/main.tf
@@ -96,7 +96,7 @@ resource "azurerm_key_vault_access_policy" "tfe_kv_acl" {
 
   key_vault_id = var.certificate.key_vault_id
   tenant_id    = var.tenant_id
-  object_id    = azurerm_user_assigned_identity.tfe_ag_msi[0].principal_id
+  object_id    = azurerm_user_assigned_identity.tfe_ag_msi[0].id
 
   certificate_permissions = [
     "get",
@@ -162,7 +162,7 @@ resource "azurerm_application_gateway" "tfe_ag" {
 
   identity {
     type         = "UserAssigned"
-    identity_ids = [azurerm_user_assigned_identity.tfe_ag_msi[0].id]
+    identity_ids = [azurerm_key_vault_access_policy.tfe_kv_acl[0].object_id]
   }
 
   gateway_ip_configuration {

--- a/modules/load_balancer/main.tf
+++ b/modules/load_balancer/main.tf
@@ -96,7 +96,7 @@ resource "azurerm_key_vault_access_policy" "tfe_kv_acl" {
 
   key_vault_id = var.certificate.key_vault_id
   tenant_id    = var.tenant_id
-  object_id    = azurerm_user_assigned_identity.tfe_ag_msi[0].principal_id
+  object_id    = azurerm_user_assigned_identity.tfe_ag_msi[0].id
 
   certificate_permissions = [
     "get",

--- a/modules/load_balancer/main.tf
+++ b/modules/load_balancer/main.tf
@@ -96,7 +96,7 @@ resource "azurerm_key_vault_access_policy" "tfe_kv_acl" {
 
   key_vault_id = var.certificate.key_vault_id
   tenant_id    = var.tenant_id
-  object_id    = azurerm_user_assigned_identity.tfe_ag_msi[0].id
+  object_id    = azurerm_user_assigned_identity.tfe_ag_msi[0].principal_id
 
   certificate_permissions = [
     "get",
@@ -162,7 +162,7 @@ resource "azurerm_application_gateway" "tfe_ag" {
 
   identity {
     type         = "UserAssigned"
-    identity_ids = [azurerm_key_vault_access_policy.tfe_kv_acl[0].object_id]
+    identity_ids = [azurerm_user_assigned_identity.tfe_ag_msi[0].id]
   }
 
   gateway_ip_configuration {

--- a/modules/load_balancer/main.tf
+++ b/modules/load_balancer/main.tf
@@ -96,7 +96,7 @@ resource "azurerm_key_vault_access_policy" "tfe_kv_acl" {
 
   key_vault_id = var.certificate.key_vault_id
   tenant_id    = var.tenant_id
-  object_id    = azurerm_user_assigned_identity.tfe_ag_msi[0].id
+  object_id    = azurerm_user_assigned_identity.tfe_ag_msi[0].principal_id
 
   certificate_permissions = [
     "get",


### PR DESCRIPTION
## Background

The latest [nightly build](https://app.circleci.com/pipelines/github/hashicorp/ptfe-replicated/2420/workflows/9c3a9e8d-94ab-4021-819f-9ca015863665/jobs/18687?invite=true#step-110-884) failed the Azure tests because the Application Gateway failed to be created due to missing permissions for the Key Vault. It appears that this was caused by a race condition as `azurerm_application_gateway.tfe_ag` had no dependency on `azurerm_key_vault_access_policy.tfe_kv_acl[0]`. This branch fixes the issue by updating the application gateway to read the user assigned identity ID through the Key Vault access policy.

## How Has This Been Tested

We'll test here and in the nightly post-merge.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://user-images.githubusercontent.com/10655063/144623480-bc468c53-4aaf-4d69-8475-6a7a9e9f1a2f.gif)

