### PR TITLE
Use ptfedev-com-dns-tls

### DIFF
--- a/tests/standalone-external/main.tf
+++ b/tests/standalone-external/main.tf
@@ -17,7 +17,7 @@ module "standalone_external" {
   domain_name             = "team-private-terraform-enterprise.azure.ptfedev.com"
   friendly_name_prefix    = local.friendly_name_prefix
   location                = "Central US"
-  resource_group_name_dns = "ptfeacc-rg"
+  resource_group_name_dns = "ptfedev-com-dns-tls"
 
   # Bootstrapping resources
   load_balancer_certificate = data.azurerm_key_vault_certificate.load_balancer

--- a/tests/standalone-poc/main.tf
+++ b/tests/standalone-poc/main.tf
@@ -17,7 +17,7 @@ module "standalone_poc" {
   domain_name             = "team-private-terraform-enterprise.azure.ptfedev.com"
   friendly_name_prefix    = local.friendly_name_prefix
   location                = "Central US"
-  resource_group_name_dns = "ptfeacc-rg"
+  resource_group_name_dns = "ptfedev-com-dns-tls"
 
   # Bootstrapping resources
   load_balancer_certificate = data.azurerm_key_vault_certificate.load_balancer


### PR DESCRIPTION
## Background

This branch updates the standalone-poc and standalone-external tests to use the new ptfedev-com-dns-tls resource group.


Relates https://github.com/hashicorp/ptfedev-infra/pull/332


## How Has This Been Tested

To be tested by the nightly build.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media3.giphy.com/media/xT1R9PCsF47Wc4dmdG/giphy.gif?cid=5a38a5a2mamdyffnrng0a0h9o5mzf3n4shhp5xxtkpgvbalk&rid=giphy.gif&ct=g)
