### PR TITLE
add variable for availability zone for PG

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -172,12 +172,15 @@ module "database" {
   resource_group_name  = module.resource_groups.resource_group_name
   location             = var.location
 
-  database_machine_type        = var.database_machine_type
-  database_private_dns_zone_id = local.network.database_private_dns_zone.id
-  database_size_mb             = var.database_size_mb
-  database_subnet_id           = local.network.database_subnet.id
-  database_user                = var.database_user
-  database_version             = var.database_version
+  database_machine_type          = var.database_machine_type
+  database_private_dns_zone_id   = local.network.database_private_dns_zone.id
+  database_size_mb               = var.database_size_mb
+  database_subnet_id             = local.network.database_subnet.id
+  database_user                  = var.database_user
+  database_version               = var.database_version
+  database_backup_retention_days = var.database_backup_retention_days
+  database_availability_zone     = var.database_availability_zone
+
 
   tags = var.tags
 }

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -17,4 +17,5 @@ resource "azurerm_postgresql_flexible_server" "tfe_pg" {
   storage_mb             = var.database_size_mb
   tags                   = var.tags
   version                = var.database_version
+  zone                   = var.database_availability_zone
 }

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -20,7 +20,6 @@ variable "resource_group_name" {
 # Database
 # --------
 variable "database_user" {
-  default     = "tfeuser"
   type        = string
   description = "Postgres username"
 }
@@ -50,11 +49,33 @@ variable "database_private_dns_zone_id" {
   description = "The identity of the private DNS zone in which the database will be deployed."
 }
 
-# ----
 variable "database_backup_retention_days" {
-  default     = 7
   type        = number
-  description = "Backup retention days for the PostgreSQL server. Supported values are between 7 and 35 days"
+  description = "Backup retention days for the PostgreSQL server."
+
+  validation {
+    condition = (
+      var.database_backup_retention_days >= 7 &&
+      var.database_backup_retention_days <= 35
+    )
+
+    error_message = "Supported values for database_backup_retention_days are between 7 and 35 days."
+  }
+}
+
+variable "database_availability_zone" {
+  type        = number
+  description = "The Availability Zone of the PostgreSQL Flexible Server."
+
+  validation {
+    condition = (
+      var.database_availability_zone == 1 ||
+      var.database_availability_zone == 2 ||
+      var.database_availability_zone == 3
+    )
+
+    error_message = "Possible values for database_availability_zone are 1, 2 and 3."
+  }
 }
 
 # Tagging

--- a/variables.tf
+++ b/variables.tf
@@ -220,6 +220,37 @@ variable "database_version" {
   description = "Postgres version"
 }
 
+variable "database_backup_retention_days" {
+  default     = 7
+  type        = number
+  description = "Backup retention days for the PostgreSQL server."
+
+  validation {
+    condition = (
+      var.database_backup_retention_days >= 7 &&
+      var.database_backup_retention_days <= 35
+    )
+
+    error_message = "Supported values for database_backup_retention_days are between 7 and 35 days."
+  }
+}
+
+variable "database_availability_zone" {
+  default     = 1
+  type        = number
+  description = "The Availability Zone of the PostgreSQL Flexible Server."
+
+  validation {
+    condition = (
+      var.database_availability_zone == 1 ||
+      var.database_availability_zone == 2 ||
+      var.database_availability_zone == 3
+    )
+
+    error_message = "Possible values for database_availability_zone are 1, 2 and 3."
+  }
+}
+
 # Load Balancer
 # -------------
 variable "load_balancer_type" {


### PR DESCRIPTION
## Background

I ran into [this error](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/runs/4721563422?check_suite_focus=true#step:10:431) when I tried to reapply Terraform against an existing environment with an `azurerm_postgresql_flexible_server` resource:
```
Error: `zone` and `high_availability.0.standby_availability_zone` should only be either exchanged with each other or unchanged
```

And I found this [issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/14397) which described my failure exactly. It was said to have been fixed in [this merge](https://github.com/hashicorp/terraform-provider-azurerm/pull/14587), however, it was only a documentation update and not a bug fix. Therefore, we must treat the `zone` argument as required and not optional. 

In addition, while I was in there, I added a `database_backup_retention_days` variable to the root module that only existed in the `database` module.

## How Has This Been Tested

When I added the `zone` argument and reran Terraform against an existing environment, it passed [here](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/runs/4730225788?check_suite_focus=true).

I will test it again here, though, with a `/test all`.

## This PR makes me feel

![hard hat zone](https://media.giphy.com/media/l0G18zE1Gxv89GdCo/giphy.gif)
