### PR TITLE
Scale down default Redis size

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -343,7 +343,7 @@ variable "redis_sku_name" {
 }
 
 variable "redis_size" {
-  default     = "3"
+  default     = "1"
   type        = string
   description = "The size of the Redis cache to deploy. Valid values for a SKU family of C (Basic/Standard) are 0, 1, 2, 3, 4, 5, 6, and for P (Premium) family are 1, 2, 3, 4."
 }


### PR DESCRIPTION
## Background

The P3 size has 26GB of cache and costs $1485.17 per month. The P1 has 6GB of cache and costs $370.96 per month. The 6GB size is more than enough for intense workloads.

## How Has This Been Tested

N/A

### Test Configuration

N/A

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media.giphy.com/media/xUNd9KuqkEuWwgZ9u0/giphy.gif)
