### PR TITLE
only allow ssh with standalone

### DIFF
--- a/modules/load_balancer/main.tf
+++ b/modules/load_balancer/main.tf
@@ -408,7 +408,7 @@ resource "azurerm_lb_rule" "tfe_load_balancer_rule_app" {
 }
 
 resource "azurerm_lb_probe" "tfe_load_balancer_probe_ssh" {
-  count = var.enable_ssh && var.load_balancer_type == "load_balancer" ? 1 : 0
+  count = var.enable_ssh && var.load_balancer_type == "load_balancer" && !var.active_active ? 1 : 0
 
   name                = "${var.friendly_name_prefix}-lb-probe-ssh"
   resource_group_name = var.resource_group_name
@@ -419,7 +419,7 @@ resource "azurerm_lb_probe" "tfe_load_balancer_probe_ssh" {
 }
 
 resource "azurerm_lb_rule" "tfe_load_balancer_rule_ssh" {
-  count = var.enable_ssh && var.load_balancer_type == "load_balancer" ? 1 : 0
+  count = var.enable_ssh && var.load_balancer_type == "load_balancer" && !var.active_active ? 1 : 0
 
   name                = "${var.friendly_name_prefix}-lb-rule-ssh"
   resource_group_name = var.resource_group_name

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -68,7 +68,7 @@ resource "azurerm_network_security_group" "tfe_network_private_nsg" {
 
   # Allow inbound SSH from bastion subnet
   dynamic "security_rule" {
-    for_each = var.create_bastion || var.enable_ssh && var.load_balancer_type == "load_balancer" ? [1] : []
+    for_each = var.create_bastion || var.enable_ssh && var.load_balancer_type == "load_balancer" && !var.active_active ? [1] : []
 
     content {
       name      = "allow-private-inbound-ssh"


### PR DESCRIPTION
## Background

Asana task: https://app.asana.com/0/1181500399442529/1201752311630244/f
Relates: #147 #148 

I realized after merging #148 that I failed to ensure that you could only implement SSH when it was a standalone deployment. This branch adds the extra logic that checks for it being active-active or not (having >1 nodes) and doesn't allow for SSH if it is.

## How Has This Been Tested

Tested here in this PR and [here](https://app.circleci.com/pipelines/github/hashicorp/ptfe-replicated/2820/workflows/aaab5e11-baf1-4c0a-af74-8ef8a5be2b05) in `ptfe-replicated`. Results:
* `standalone_external` [artifacts](https://app.circleci.com/pipelines/github/hashicorp/ptfe-replicated/2820/workflows/aaab5e11-baf1-4c0a-af74-8ef8a5be2b05/jobs/19833/artifacts)
* `standalone_poc` [artifacts](https://app.circleci.com/pipelines/github/hashicorp/ptfe-replicated/2820/workflows/aaab5e11-baf1-4c0a-af74-8ef8a5be2b05/jobs/19834/artifacts)

## This PR makes me feel

![if only i had seen it before](https://media.giphy.com/media/Tj5AsFCJFfFrfQTV6M/giphy.gif)
