### PR TITLE
default to GRS storage

### DIFF
--- a/modules/object_storage/variables.tf
+++ b/modules/object_storage/variables.tf
@@ -30,15 +30,28 @@ variable "storage_account_container_name" {
 }
 
 variable "storage_account_tier" {
-  default     = "Standard"
   type        = string
   description = "Storage account tier Standard or Premium"
 }
 
 variable "storage_account_replication_type" {
-  default     = "ZRS"
   type        = string
-  description = "Storage account type LRS, GRS, RAGRS, ZRS"
+  description = <<-EOD
+  Storage account type LRS, GRS, RAGRS, ZRS. NOTE: This is defaulted to 'GRS' because of a known
+  intermittent error sited here: https://github.com/hashicorp/terraform-provider-azurerm/issues/5299
+  EOD
+
+  validation {
+    condition = (
+      var.storage_account_replication_type == "LRS" ||
+      var.storage_account_replication_type == "GRS" ||
+      var.storage_account_replication_type == "RAGRS" ||
+      var.storage_account_replication_type == "ZRS" ||
+      var.storage_account_replication_type == null
+    )
+
+    error_message = "Supported values for storage_account_replication_type are 'LRS', 'GRS', 'RAGRS', and 'ZRS'."
+  }
 }
 
 variable "storage_account_key" {
@@ -54,7 +67,6 @@ variable "storage_account_primary_blob_connection_string" {
 # Tagging
 # -------
 variable "tags" {
-  default     = {}
   type        = map(string)
   description = "Map of tags for resource"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -195,9 +195,24 @@ variable "storage_account_tier" {
 }
 
 variable "storage_account_replication_type" {
-  default     = "ZRS"
+  default     = "GRS"
   type        = string
-  description = "Storage account type LRS, GRS, RAGRS, ZRS"
+  description = <<-EOD
+  Storage account type LRS, GRS, RAGRS, ZRS. NOTE: This is defaulted to 'GRS' because of a known
+  intermittent error sited here: https://github.com/hashicorp/terraform-provider-azurerm/issues/5299
+  EOD
+
+  validation {
+    condition = (
+      var.storage_account_replication_type == "LRS" ||
+      var.storage_account_replication_type == "GRS" ||
+      var.storage_account_replication_type == "RAGRS" ||
+      var.storage_account_replication_type == "ZRS" ||
+      var.storage_account_replication_type == null
+    )
+
+    error_message = "Supported values for storage_account_replication_type are 'LRS', 'GRS', 'RAGRS', and 'ZRS'."
+  }
 }
 
 # Database


### PR DESCRIPTION
## Background

This branch changes the default storage account replication type to Geo-Redundant Storage (GRS) and removes the remaining default values in the object storage module in favor of them being defaulted in the root module's variables.

In [this issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/5299), it was suggested [here](https://github.com/hashicorp/terraform-provider-azurerm/issues/5299#issuecomment-980079517) that changing the storage tier to [Geo-Redundant Storage](https://docs.microsoft.com/en-us/azure/storage/common/storage-redundancy#geo-redundant-storage) would avoid the error that the Azure API cannot find the storage account, such as we see in [these tests](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/pull/150#issuecomment-1036391935).

Relates to #150 

## How Has This Been Tested

- [x] Successfully tested here

## This PR makes me feel

![that's enough of that](https://media.giphy.com/media/3o6wrcjqboQUXl2gog/giphy.gif)
