### PR TITLE
Enable necessary extensions for Azure PostgreSQL

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -119,6 +119,7 @@ module "database" {
   database_private_dns_zone_id   = local.network.database_private_dns_zone.id
   database_size_mb               = var.database_size_mb
   database_subnet_id             = local.network.database_subnet.id
+  database_name                  = var.database_name
   database_user                  = var.database_user
   database_version               = var.database_version
   database_backup_retention_days = var.database_backup_retention_days

--- a/main.tf
+++ b/main.tf
@@ -121,6 +121,7 @@ module "database" {
   database_subnet_id             = local.network.database_subnet.id
   database_name                  = var.database_name
   database_user                  = var.database_user
+  database_extensions            = var.database_extensions
   database_version               = var.database_version
   database_backup_retention_days = var.database_backup_retention_days
   database_availability_zone     = var.database_availability_zone

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -3,7 +3,7 @@ resource "random_string" "tfe_pg_password" {
   special = true
 }
 
-resource "azurerm_postgresql_flexible_server" "tfe_pg" {
+resource "azurerm_postgresql_flexible_server" "tfe" {
   location            = var.location
   name                = "${var.friendly_name_prefix}-pg"
   resource_group_name = var.resource_group_name
@@ -18,4 +18,22 @@ resource "azurerm_postgresql_flexible_server" "tfe_pg" {
   tags                   = var.tags
   version                = var.database_version
   zone                   = var.database_availability_zone
+}
+
+resource "azurerm_postgresql_flexible_server_configuration" "tfe" {
+  for_each = {
+    "hstore"    = "on",
+    "uuid-ossp" = "on",
+    "citext"    = "on",
+  }
+  name      = each.key
+  server_id = azurerm_postgresql_flexible_server.tfe.id
+  value     = each.value
+}
+
+resource "azurerm_postgresql_flexible_server_database" "tfe" {
+  name      = var.database_name
+  server_id = azurerm_postgresql_flexible_server.tfe.id
+  collation = "en_US.utf8"
+  charset   = "utf8"
 }

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -21,14 +21,9 @@ resource "azurerm_postgresql_flexible_server" "tfe" {
 }
 
 resource "azurerm_postgresql_flexible_server_configuration" "tfe" {
-  for_each = {
-    "hstore"    = "on",
-    "uuid-ossp" = "on",
-    "citext"    = "on",
-  }
-  name      = each.key
+  name      = "azure.extensions"
   server_id = azurerm_postgresql_flexible_server.tfe.id
-  value     = each.value
+  value     = join(",", var.database_extensions)
 }
 
 resource "azurerm_postgresql_flexible_server_database" "tfe" {

--- a/modules/database/outputs.tf
+++ b/modules/database/outputs.tf
@@ -1,17 +1,16 @@
 output "address" {
-  value = "${azurerm_postgresql_flexible_server.tfe_pg.fqdn}:5432"
+  value = "${azurerm_postgresql_flexible_server.tfe.fqdn}:5432"
 
   description = "The address of the PostgreSQL database."
 }
 output "name" {
-  # This is the name of the default database created with the server.
-  value = "postgres"
+  value = azurerm_postgresql_flexible_server_database.tfe.name
 
   description = "The name of the PostgreSQL database."
 }
 
 output "server" {
-  value = azurerm_postgresql_flexible_server.tfe_pg
+  value = azurerm_postgresql_flexible_server.tfe
 
   description = "The PostgreSQL server."
 }

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -19,6 +19,11 @@ variable "resource_group_name" {
 
 # Database
 # --------
+variable "database_name" {
+  type        = string
+  description = "The name of the PostgreSQL database."
+}
+
 variable "database_user" {
   type        = string
   description = "Postgres username"

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -29,6 +29,11 @@ variable "database_user" {
   description = "Postgres username"
 }
 
+variable "database_extensions" {
+  type        = list(string)
+  description = "A list of PostgreSQL extensions to enable."
+}
+
 variable "database_machine_type" {
   type        = string
   description = "Postgres sku short name: tier + family + cores"

--- a/variables.tf
+++ b/variables.tf
@@ -240,6 +240,12 @@ variable "storage_account_replication_type" {
 
 # Database
 # --------
+variable "database_name" {
+  type        = string
+  default     = "tfe_db"
+  description = "The name of the PostgreSQL database."
+}
+
 variable "database_user" {
   default     = "tfeuser"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -252,6 +252,16 @@ variable "database_user" {
   description = "Postgres username"
 }
 
+variable "database_extensions" {
+  default = [
+    "CITEXT",
+    "HSTORE",
+    "UUID-OSSP",
+  ]
+  type        = list(string)
+  description = "A list of PostgreSQL extensions to enable."
+}
+
 variable "database_machine_type" {
   default     = "GP_Standard_D4s_v3"
   type        = string


### PR DESCRIPTION
## Background

Azure Database for PostgreSQL Flexible Server [requires that extensions be enabled](https://docs.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-extensions) before they can be installed and used.

If they aren't, you'll see an error like this:

```
2022-03-01T05:26:45.680615520Z PG::FeatureNotSupported: ERROR:  extension "hstore" is not allow-listed for "azure_pg_admin" users in Azure Database for PostgreSQL
```

## How Has This Been Tested

Via pull request.

### Test Configuration

* Terraform Version:
* Any additional relevant variables:

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media.giphy.com/media/3ohhwoWSCtJzznXbuo/giphy.gif)
