### PR TITLE
use default database

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -119,7 +119,6 @@ module "database" {
   database_private_dns_zone_id   = local.network.database_private_dns_zone.id
   database_size_mb               = var.database_size_mb
   database_subnet_id             = local.network.database_subnet.id
-  database_name                  = var.database_name
   database_user                  = var.database_user
   database_extensions            = var.database_extensions
   database_version               = var.database_version

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -25,10 +25,3 @@ resource "azurerm_postgresql_flexible_server_configuration" "tfe" {
   server_id = azurerm_postgresql_flexible_server.tfe.id
   value     = join(",", var.database_extensions)
 }
-
-resource "azurerm_postgresql_flexible_server_database" "tfe" {
-  name      = var.database_name
-  server_id = azurerm_postgresql_flexible_server.tfe.id
-  collation = "en_US.utf8"
-  charset   = "utf8"
-}

--- a/modules/database/outputs.tf
+++ b/modules/database/outputs.tf
@@ -3,8 +3,10 @@ output "address" {
 
   description = "The address of the PostgreSQL database."
 }
+
 output "name" {
-  value = azurerm_postgresql_flexible_server_database.tfe.name
+  # This is the name of the default database created with the server.
+  value = "postgres"
 
   description = "The name of the PostgreSQL database."
 }

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -19,11 +19,6 @@ variable "resource_group_name" {
 
 # Database
 # --------
-variable "database_name" {
-  type        = string
-  description = "The name of the PostgreSQL database."
-}
-
 variable "database_user" {
   type        = string
   description = "Postgres username"

--- a/variables.tf
+++ b/variables.tf
@@ -240,12 +240,6 @@ variable "storage_account_replication_type" {
 
 # Database
 # --------
-variable "database_name" {
-  type        = string
-  default     = "tfe_db"
-  description = "The name of the PostgreSQL database."
-}
-
 variable "database_user" {
   default     = "tfeuser"
   type        = string


### PR DESCRIPTION
## Background

The last change that was introduced, #156, was successfully tested, however, in the `ptfe-replicated` `standalone_external` test, we are finding intermittent failures in the destroy where there is a race condition outlined [here](https://github.com/hashicorp/terraform-provider-azurerm/issues/15728).

This branch reverts back to using the default database instead of an explicitly created one because of said race condition.

## How Has This Been Tested

- [ ] `ptfe-replicated` [standalone_external test](https://app.circleci.com/pipelines/github/hashicorp/ptfe-replicated/3100/workflows/f49512c6-9381-47ac-92a3-fa7ceb603593/jobs/20747)
- [ ] tested here

## This PR makes me feel

![revert](https://media.giphy.com/media/143vPc6b08locw/giphy.gif)
