### PR TITLE
change secret input for tfe_init

### DIFF
--- a/examples/standalone_airgap_dev/main.tf
+++ b/examples/standalone_airgap_dev/main.tf
@@ -27,7 +27,7 @@ module "standalone_airgap_dev" {
   # Bootstrapping resources
   airgap_url                                = var.airgap_url
   tfe_license_bootstrap_airgap_package_path = "/var/lib/ptfe/ptfe.airgap"
-  tfe_license_secret                        = module.secrets.tfe_license
+  tfe_license_secret_id                     = module.secrets.tfe_license_secret_id
   tls_bootstrap_cert_pathname               = "/var/lib/terraform-enterprise/certificate.pem"
   tls_bootstrap_key_pathname                = "/var/lib/terraform-enterprise/key.pem"
   vm_certificate_secret                     = data.azurerm_key_vault_secret.vm_certificate

--- a/examples/standalone_mounted_disk/main.tf
+++ b/examples/standalone_mounted_disk/main.tf
@@ -26,7 +26,7 @@ module "standalone_mounted_disk" {
 
   # Bootstrapping resources
   load_balancer_certificate   = data.azurerm_key_vault_certificate.load_balancer
-  tfe_license_secret          = module.secrets.tfe_license
+  tfe_license_secret_id       = module.secrets.tfe_license_secret_id
   vm_certificate_secret       = data.azurerm_key_vault_secret.vm_certificate
   vm_key_secret               = data.azurerm_key_vault_secret.vm_key
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"

--- a/fixtures/secrets/outputs.tf
+++ b/fixtures/secrets/outputs.tf
@@ -1,12 +1,6 @@
-output "tfe_license" {
-  value = var.tfe_license == null ? {
-    name = null
-    id   = null
-    } : {
-    name = azurerm_key_vault_secret.tfe_license[0].name
-    id   = azurerm_key_vault_secret.tfe_license[0].id
-  }
-  description = "The Key Vault secret of the Base64 encoded TFE license."
+output "tfe_license_secret_id" {
+  value       = var.tfe_license == null ? null : azurerm_key_vault_secret.tfe_license[0].id
+  description = "The Key Vault secret ID of the Base64 encoded TFE license."
   sensitive   = true
 }
 
@@ -24,13 +18,15 @@ output "private_key_pem" {
 
 output "chained_certificate_pem" {
   value = var.chained_certificate_pem == null ? {
-    name   = null
-    secret = null
-    id     = null
+    name         = null
+    secret       = null
+    id           = null
+    key_vault_id = null
     } : {
-    name   = azurerm_key_vault_secret.chained_certificate_pem[0].name
-    secret = azurerm_key_vault_secret.chained_certificate_pem[0].value
-    id     = azurerm_key_vault_secret.chained_certificate_pem[0].id
+    name         = azurerm_key_vault_secret.chained_certificate_pem[0].name
+    secret       = azurerm_key_vault_secret.chained_certificate_pem[0].value
+    id           = azurerm_key_vault_secret.chained_certificate_pem[0].id
+    key_vault_id = azurerm_key_vault_secret.chained_certificate_pem[0].key_vault_id
   }
   description = "The Key Vault secret which will be used for the vm_certificate_secret variable in the root module."
   sensitive   = true
@@ -38,11 +34,13 @@ output "chained_certificate_pem" {
 
 output "proxy_public_key" {
   value = var.proxy_public_key == null ? {
-    name   = null
-    secret = null
+    name         = null
+    secret       = null
+    key_vault_id = null
     } : {
-    name   = azurerm_key_vault_secret.proxy_public_key[0].name
-    secret = azurerm_key_vault_secret.proxy_public_key[0].value
+    name         = azurerm_key_vault_secret.proxy_public_key[0].name
+    secret       = azurerm_key_vault_secret.proxy_public_key[0].value
+    key_vault_id = azurerm_key_vault_secret.proxy_public_key[0].key_vault_id
   }
   description = "The Key Vault secret which will be used for the SSH public_key argument when creating the proxy virtual machine."
   sensitive   = true
@@ -62,13 +60,15 @@ output "proxy_private_key" {
 
 output "ca_certificate" {
   value = var.ca_certificate == null ? {
-    name   = null
-    secret = null
-    id     = null
+    name         = null
+    secret       = null
+    id           = null
+    key_vault_id = null
     } : {
-    name   = azurerm_key_vault_secret.ca_certificate[0].name
-    secret = azurerm_key_vault_secret.ca_certificate[0].value
-    id     = azurerm_key_vault_secret.ca_certificate[0].id
+    name         = azurerm_key_vault_secret.ca_certificate[0].name
+    secret       = azurerm_key_vault_secret.ca_certificate[0].value
+    id           = azurerm_key_vault_secret.ca_certificate[0].id
+    key_vault_id = azurerm_key_vault_secret.ca_certificate[0].key_vault_id
   }
   description = "The Key Vault secret of the Base64 encoded CA certificate to be trusted by the proxy virtual machine."
   sensitive   = true
@@ -76,13 +76,15 @@ output "ca_certificate" {
 
 output "ca_private_key" {
   value = var.ca_private_key == null ? {
-    name   = null
-    secret = null
-    id     = null
+    name         = null
+    secret       = null
+    id           = null
+    key_vault_id = null
     } : {
-    name   = azurerm_key_vault_secret.ca_private_key[0].name
-    secret = azurerm_key_vault_secret.ca_private_key[0].value
-    id     = azurerm_key_vault_secret.ca_private_key[0].id
+    name         = azurerm_key_vault_secret.ca_private_key[0].name
+    secret       = azurerm_key_vault_secret.ca_private_key[0].value
+    id           = azurerm_key_vault_secret.ca_private_key[0].id
+    key_vault_id = azurerm_key_vault_secret.ca_private_key[0].key_vault_id
   }
   description = "The Key Vault secret of the Base64 encoded CA private key."
   sensitive   = true
@@ -90,11 +92,13 @@ output "ca_private_key" {
 
 output "bastion_public_key" {
   value = var.bastion_public_key == null ? {
-    name   = null
-    secret = null
+    name         = null
+    secret       = null
+    key_vault_id = null
     } : {
-    name   = azurerm_key_vault_secret.bastion_public_key[0].name
-    secret = azurerm_key_vault_secret.bastion_public_key[0].value
+    name         = azurerm_key_vault_secret.bastion_public_key[0].name
+    secret       = azurerm_key_vault_secret.bastion_public_key[0].value
+    key_vault_id = azurerm_key_vault_secret.bastion_public_key[0].key_vault_id
   }
   description = "The Key Vault secret which will be used for the SSH public key of the bastion virtual machine."
   sensitive   = true
@@ -102,11 +106,13 @@ output "bastion_public_key" {
 
 output "bastion_private_key" {
   value = var.bastion_private_key == null ? {
-    name   = null
-    secret = null
+    name         = null
+    secret       = null
+    key_vault_id = null
     } : {
-    name   = azurerm_key_vault_secret.bastion_private_key[0].name
-    secret = azurerm_key_vault_secret.bastion_private_key[0].value
+    name         = azurerm_key_vault_secret.bastion_private_key[0].name
+    secret       = azurerm_key_vault_secret.bastion_private_key[0].value
+    key_vault_id = azurerm_key_vault_secret.bastion_private_key[0].key_vault_id
   }
   description = "The Key Vault secret which will be used for the SSH private key of the bastion virtual machine."
   sensitive   = true

--- a/main.tf
+++ b/main.tf
@@ -133,7 +133,7 @@ module "database" {
 # TFE and Replicated settings to pass to the tfe_init module
 # -----------------------------------------------------------------------------
 module "settings" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/settings?ref=main"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/settings?ref=ah-change-secret-input"
 
   # TFE Base Configuration
   installation_type = var.installation_type
@@ -185,7 +185,7 @@ module "settings" {
 # Azure user data / cloud init used to install and configure TFE on instance(s)
 # -----------------------------------------------------------------------------
 module "tfe_init" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=main"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=ah-change-secret-input"
 
   # TFE & Replicated Configuration data
   cloud                    = "azurerm"
@@ -194,10 +194,10 @@ module "tfe_init" {
   airgap_url               = var.airgap_url
 
   # Secrets
-  ca_certificate_secret = var.ca_certificate_secret
-  certificate_secret    = var.vm_certificate_secret
-  key_secret            = var.vm_key_secret
-  tfe_license_secret    = var.tfe_license_secret
+  ca_certificate_secret_id = var.ca_certificate_secret == null ? null : var.ca_certificate_secret.id
+  certificate_secret_id    = var.vm_certificate_secret == null ? null : var.vm_certificate_secret.id
+  key_secret_id            = var.vm_key_secret == null ? null : var.vm_key_secret.id
+  tfe_license_secret_id    = var.tfe_license_secret_id
 
   # Proxy information
   proxy_ip   = var.proxy_ip

--- a/main.tf
+++ b/main.tf
@@ -133,7 +133,7 @@ module "database" {
 # TFE and Replicated settings to pass to the tfe_init module
 # -----------------------------------------------------------------------------
 module "settings" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/settings?ref=ah-change-secret-input"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/settings?ref=main"
 
   # TFE Base Configuration
   installation_type = var.installation_type
@@ -185,7 +185,7 @@ module "settings" {
 # Azure user data / cloud init used to install and configure TFE on instance(s)
 # -----------------------------------------------------------------------------
 module "tfe_init" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=ah-change-secret-input"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=main"
 
   # TFE & Replicated Configuration data
   cloud                    = "azurerm"

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -32,7 +32,7 @@ module "private_active_active" {
 
   # Bootstrapping resources
   load_balancer_certificate   = data.azurerm_key_vault_certificate.load_balancer
-  tfe_license_secret          = data.azurerm_key_vault_secret.tfe_license
+  tfe_license_secret_id       = data.azurerm_key_vault_secret.tfe_license.id
   vm_certificate_secret       = data.azurerm_key_vault_secret.vm_certificate
   vm_key_secret               = data.azurerm_key_vault_secret.vm_key
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -31,7 +31,7 @@ module "private_tcp_active_active" {
   iact_subnet_list        = ["${module.bastion_vm.private_ip}/32"]
 
   # Bootstrapping resources
-  tfe_license_secret          = data.azurerm_key_vault_secret.tfe_license
+  tfe_license_secret_id       = data.azurerm_key_vault_secret.tfe_license.id
   vm_certificate_secret       = data.azurerm_key_vault_secret.vm_certificate
   vm_key_secret               = data.azurerm_key_vault_secret.vm_key
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -15,7 +15,7 @@ module "public_active_active" {
 
   # Bootstrapping resources
   load_balancer_certificate   = data.azurerm_key_vault_certificate.load_balancer
-  tfe_license_secret          = data.azurerm_key_vault_secret.tfe_license
+  tfe_license_secret_id       = data.azurerm_key_vault_secret.tfe_license.id
   vm_certificate_secret       = data.azurerm_key_vault_secret.vm_certificate
   vm_key_secret               = data.azurerm_key_vault_secret.vm_key
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"

--- a/tests/standalone-external/main.tf
+++ b/tests/standalone-external/main.tf
@@ -26,7 +26,7 @@ module "standalone_external" {
 
   # Bootstrapping resources
   load_balancer_certificate   = data.azurerm_key_vault_certificate.load_balancer
-  tfe_license_secret          = module.secrets.tfe_license
+  tfe_license_secret_id       = module.secrets.tfe_license_secret_id
   vm_certificate_secret       = data.azurerm_key_vault_secret.vm_certificate
   vm_key_secret               = data.azurerm_key_vault_secret.vm_key
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"

--- a/tests/standalone-poc/main.tf
+++ b/tests/standalone-poc/main.tf
@@ -27,7 +27,7 @@ module "standalone_poc" {
 
   # Bootstrapping resources
   load_balancer_certificate   = data.azurerm_key_vault_certificate.load_balancer
-  tfe_license_secret          = module.secrets.tfe_license
+  tfe_license_secret_id       = module.secrets.tfe_license_secret_id
   vm_certificate_secret       = data.azurerm_key_vault_secret.vm_certificate
   vm_key_secret               = data.azurerm_key_vault_secret.vm_key
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"

--- a/variables.tf
+++ b/variables.tf
@@ -153,12 +153,10 @@ variable "network_allow_range" {
 
 # TFE License
 # -----------
-variable "tfe_license_secret" {
-  default = null
-  type = object({
-    id = string
-  })
-  description = "The Key Vault secret under which the Base64 encoded TFE license is stored."
+variable "tfe_license_secret_id" {
+  default     = null
+  type        = string
+  description = "The Key Vault secret ID under which the Base64 encoded TFE license is stored."
 }
 
 # Air-gapped Installations ONLY


### PR DESCRIPTION
## Background

This branch simplifies the secret variables for the tfe_init script to take strings instead of objects. This will bring the Azure module outputs into parity with the GCP and AWS modules so that we can standardize the tfe_init inputs.

- [x] [terraform-random-tfe-utility](https://github.com/hashicorp/terraform-random-tfe-utility/pull/11) is merged

## How Has This Been Tested

- [x] Here
- [x] [ptfe-replicated tests](https://app.circleci.com/pipelines/github/hashicorp/ptfe-replicated?branch=ah-test-secret-input&filter=all) pass

## This PR makes me feel

![consistency](https://media.giphy.com/media/PqFxlD2TGJWlPpOs8G/giphy.gif)
