### PR TITLE
Checkout default branch for load test

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Checkout TFE Load Test
         uses: actions/checkout@v2
         with:
-          ref: 'master'
           path: ${{ env.K6_WORK_DIR_PATH }}
           repository: hashicorp/tfe-load-test
           token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}
@@ -216,7 +215,6 @@ jobs:
       - name: Checkout TFE Load Test
         uses: actions/checkout@v2
         with:
-          ref: 'master'
           path: ${{ env.K6_WORK_DIR_PATH }}
           repository: hashicorp/tfe-load-test
           token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}
@@ -428,7 +426,6 @@ jobs:
       - name: Checkout TFE Load Test
         uses: actions/checkout@v2
         with:
-          ref: 'master'
           path: ${{ env.K6_WORK_DIR_PATH }}
           repository: hashicorp/tfe-load-test
           token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}


### PR DESCRIPTION
## Background

We were checking out `master` specifically. However, we renamed `master` to `main`. This updates the checkout action to just checkout the default branch.

## How Has This Been Tested

Via CI/CD.

### Test Configuration

N/A

## This PR makes me feel

![optional gif describing your feelings about this pr]()
