### PR TITLE
Doormat support

### DIFF
--- a/tests/standalone-external/main.tf
+++ b/tests/standalone-external/main.tf
@@ -19,10 +19,10 @@ module "secrets" {
 module "standalone_external" {
   source = "../../"
 
-  domain_name             = "team-private-terraform-enterprise.azure.ptfedev.com"
+  domain_name             = var.domain_name
   friendly_name_prefix    = local.friendly_name_prefix
   location                = "Central US"
-  resource_group_name_dns = "ptfedev-com-dns-tls"
+  resource_group_name_dns = var.resource_group_name_dns
 
   # Bootstrapping resources
   load_balancer_certificate   = data.azurerm_key_vault_certificate.load_balancer

--- a/tests/standalone-external/variables.tf
+++ b/tests/standalone-external/variables.tf
@@ -1,3 +1,10 @@
+
+variable "domain_name" {
+  type        = string
+  default     = "team-private-terraform-enterprise.azure.ptfedev.com"
+  description = "Domain to create Terraform Enterprise subdomain within"
+}
+
 variable "key_vault_id" {
   type        = string
   description = "The identity of the Key Vault which contains secrets and certificates."
@@ -6,4 +13,10 @@ variable "key_vault_id" {
 variable "license_file" {
   type        = string
   description = "The local path to the Terraform Enterprise license to be provided by CI."
+}
+
+variable "resource_group_name_dns" {
+  type        = string
+  default     = "ptfedev-com-dns-tls"
+  description = "Name of resource group which contains desired DNS zone"
 }

--- a/tests/standalone-mounted-disk/main.tf
+++ b/tests/standalone-mounted-disk/main.tf
@@ -19,10 +19,10 @@ module "secrets" {
 module "standalone_mounted_disk" {
   source = "../../"
 
-  domain_name             = "team-private-terraform-enterprise.azure.ptfedev.com"
+  domain_name             = var.domain_name
   friendly_name_prefix    = local.friendly_name_prefix
   location                = "Central US"
-  resource_group_name_dns = "ptfedev-com-dns-tls"
+  resource_group_name_dns = var.resource_group_name_dns
   iact_subnet_list        = ["0.0.0.0/0"]
 
   # Bootstrapping resources

--- a/tests/standalone-mounted-disk/variables.tf
+++ b/tests/standalone-mounted-disk/variables.tf
@@ -1,3 +1,9 @@
+variable "domain_name" {
+  type        = string
+  default     = "team-private-terraform-enterprise.azure.ptfedev.com"
+  description = "Domain to create Terraform Enterprise subdomain within"
+}
+
 variable "key_vault_id" {
   type        = string
   description = "The identity of the Key Vault which contains secrets and certificates."
@@ -6,4 +12,10 @@ variable "key_vault_id" {
 variable "license_file" {
   type        = string
   description = "The local path to the Terraform Enterprise license to be provided by CI."
+}
+
+variable "resource_group_name_dns" {
+  type        = string
+  default     = "ptfedev-com-dns-tls"
+  description = "Name of resource group which contains desired DNS zone"
 }


### PR DESCRIPTION
## Background

This change adds variables for the domain name and domain resource group module variable values. This is done to support a move to a new subscription under test for standalone modules. The defaults are configured to the existing values to allow for current functioning test systems to operate as intended until after the migration is complete.


## How Has This Been Tested

Each module has been manually applied and load tests executed.

## This PR makes me feel

<img src="https://media2.giphy.com/media/xT1Ra1QNZW2LOOewq4/giphy-downsized-medium.gif"/>
