### PR TITLE
enabling github actions to execute standalone tests on stable licences

### DIFF
--- a/fixtures/secrets/versions.tf
+++ b/fixtures/secrets/versions.tf
@@ -7,6 +7,3 @@ terraform {
     }
   }
 }
-provider "azurerm" {
-  features {}
-}

--- a/tests/standalone-external/locals.tf
+++ b/tests/standalone-external/locals.tf
@@ -8,5 +8,6 @@ locals {
     OkToDelete  = "True"
   }
 
+  utility_module_test  = var.license_file == null
   friendly_name_prefix = random_string.friendly_name.id
 }

--- a/tests/standalone-external/main.tf
+++ b/tests/standalone-external/main.tf
@@ -6,8 +6,8 @@ resource "random_string" "friendly_name" {
 }
 
 module "secrets" {
+  count  = local.utility_module_test ? 0 : 1
   source = "../../fixtures/secrets"
-
   key_vault_id = var.key_vault_id
 
   tfe_license = {
@@ -26,7 +26,7 @@ module "standalone_external" {
 
   # Bootstrapping resources
   load_balancer_certificate   = data.azurerm_key_vault_certificate.load_balancer
-  tfe_license_secret_id       = module.secrets.tfe_license_secret_id
+  tfe_license_secret_id       = try(module.secrets[0].tfe_license_secret_id, var.tfe_license_secret_id)
   vm_certificate_secret       = data.azurerm_key_vault_secret.vm_certificate
   vm_key_secret               = data.azurerm_key_vault_secret.vm_key
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"

--- a/tests/standalone-external/main.tf
+++ b/tests/standalone-external/main.tf
@@ -6,8 +6,8 @@ resource "random_string" "friendly_name" {
 }
 
 module "secrets" {
-  count  = local.utility_module_test ? 0 : 1
-  source = "../../fixtures/secrets"
+  count        = local.utility_module_test ? 0 : 1
+  source       = "../../fixtures/secrets"
   key_vault_id = var.key_vault_id
 
   tfe_license = {

--- a/tests/standalone-external/variables.tf
+++ b/tests/standalone-external/variables.tf
@@ -12,6 +12,7 @@ variable "key_vault_id" {
 
 variable "license_file" {
   type        = string
+  default     = null
   description = "The local path to the Terraform Enterprise license to be provided by CI."
 }
 
@@ -19,4 +20,10 @@ variable "resource_group_name_dns" {
   type        = string
   default     = "ptfedev-com-dns-tls"
   description = "Name of resource group which contains desired DNS zone"
+}
+
+variable "tfe_license_secret_id" {
+  default     = null
+  type        = string
+  description = "The Key Vault secret id under which the Base64 encoded Terraform Enterprise license is stored."
 }

--- a/tests/standalone-mounted-disk/locals.tf
+++ b/tests/standalone-mounted-disk/locals.tf
@@ -8,5 +8,6 @@ locals {
     OkToDelete  = "True"
   }
 
+  utility_module_test  = var.license_file == null
   friendly_name_prefix = random_string.friendly_name.id
 }

--- a/tests/standalone-mounted-disk/main.tf
+++ b/tests/standalone-mounted-disk/main.tf
@@ -7,7 +7,7 @@ resource "random_string" "friendly_name" {
 
 module "secrets" {
   source = "../../fixtures/secrets"
-
+  count  = local.utility_module_test ? 0 : 1
   key_vault_id = var.key_vault_id
 
   tfe_license = {
@@ -27,7 +27,7 @@ module "standalone_mounted_disk" {
 
   # Bootstrapping resources
   load_balancer_certificate   = data.azurerm_key_vault_certificate.load_balancer
-  tfe_license_secret_id       = module.secrets.tfe_license_secret_id
+  tfe_license_secret_id       = try(module.secrets[0].tfe_license_secret_id, var.tfe_license_secret_id)
   vm_certificate_secret       = data.azurerm_key_vault_secret.vm_certificate
   vm_key_secret               = data.azurerm_key_vault_secret.vm_key
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"

--- a/tests/standalone-mounted-disk/main.tf
+++ b/tests/standalone-mounted-disk/main.tf
@@ -6,8 +6,8 @@ resource "random_string" "friendly_name" {
 }
 
 module "secrets" {
-  source = "../../fixtures/secrets"
-  count  = local.utility_module_test ? 0 : 1
+  source       = "../../fixtures/secrets"
+  count        = local.utility_module_test ? 0 : 1
   key_vault_id = var.key_vault_id
 
   tfe_license = {

--- a/tests/standalone-mounted-disk/variables.tf
+++ b/tests/standalone-mounted-disk/variables.tf
@@ -11,6 +11,7 @@ variable "key_vault_id" {
 
 variable "license_file" {
   type        = string
+  default     = null
   description = "The local path to the Terraform Enterprise license to be provided by CI."
 }
 
@@ -18,4 +19,10 @@ variable "resource_group_name_dns" {
   type        = string
   default     = "ptfedev-com-dns-tls"
   description = "Name of resource group which contains desired DNS zone"
+}
+
+variable "tfe_license_secret_id" {
+  default     = null
+  type        = string
+  description = "The Key Vault secret id under which the Base64 encoded Terraform Enterprise license is stored."
 }


### PR DESCRIPTION
## Background

This change introduces variables and patterns necessary to execute the standalone tests as github actions /test targets while consuming the shared stable channel license


## How Has This Been Tested

This change has been tested locally running the tfe-load-tests k6 soak tests.

## This PR makes me feel

<img src="https://media3.giphy.com/media/l2JehPbx5eIFLqAms/giphy.gif"/>
