### PR TITLE
Removing the default provider initialization

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -14,7 +14,3 @@ terraform {
     }
   }
 }
-provider "azurerm" {
-  features {}
-}
-


### PR DESCRIPTION

## Background

The root module contains a provider initialization.  This is problematic because this module is intended to be invoked within the context of another root module. Initializing the provider within the terraform-azurerm-terraform-enterprise module prevents the inheritance of a azurerm provider configured in the calling root module.  When resources are attempted to be deleted in this way terraform will error on missing provider configurations. This change fixes that problem.


## How Has This Been Tested

/test commands will be run from the context of this pull request.

## This PR makes me feel

<img src="https://media3.giphy.com/media/l2SpZQK6yiANOohag/giphy.gif"/>
