### PR TITLE
Arbitrary image support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -133,7 +133,7 @@ module "database" {
 # TFE and Replicated settings to pass to the tfe_init module
 # -----------------------------------------------------------------------------
 module "settings" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/settings?ref=support_rhel_8_6"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/settings?ref=main"
 
   # TFE Base Configuration
   custom_image_tag = var.custom_image_tag
@@ -186,7 +186,7 @@ module "settings" {
 # Azure user data / cloud init used to install and configure TFE on instance(s)
 # -----------------------------------------------------------------------------
 module "tfe_init" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=support_rhel_8_6"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=main"
 
   # TFE & Replicated Configuration data
   cloud                    = "azurerm"

--- a/main.tf
+++ b/main.tf
@@ -287,6 +287,10 @@ module "vm" {
   vm_data_disk_storage_account_type = var.vm_data_disk_storage_account_type
   vm_identity_type                  = var.vm_identity_type
   vm_image_id                       = var.vm_image_id
+  vm_image_publisher                = var.vm_image_publisher
+  vm_image_offer                    = var.vm_image_offer
+  vm_image_sku                      = var.vm_image_sku
+  vm_image_version                  = var.vm_image_version
   vm_node_count                     = var.vm_node_count
   vm_os_disk_caching                = var.vm_os_disk_caching
   vm_os_disk_disk_size_gb           = var.vm_os_disk_disk_size_gb

--- a/main.tf
+++ b/main.tf
@@ -133,7 +133,7 @@ module "database" {
 # TFE and Replicated settings to pass to the tfe_init module
 # -----------------------------------------------------------------------------
 module "settings" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/settings?ref=main"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/settings?ref=support_rhel_8_6"
 
   # TFE Base Configuration
   custom_image_tag = var.custom_image_tag
@@ -186,7 +186,7 @@ module "settings" {
 # Azure user data / cloud init used to install and configure TFE on instance(s)
 # -----------------------------------------------------------------------------
 module "tfe_init" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=main"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=support_rhel_8_6"
 
   # TFE & Replicated Configuration data
   cloud                    = "azurerm"

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -50,7 +50,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "tfe_vmss" {
   }
 
   # Source image id will be used if vm_image_id anything other than 'ubuntu' or 'rhel'
-  source_image_id = var.vm_image_id == "ubuntu" || var.vm_image_id == "rhel" ? null : var.vm_image_id
+  source_image_id = var.vm_image_id == "ubuntu" || var.vm_image_id == "rhel" || var.vm_image_id == "manual" ? null : var.vm_image_id
 
   # Source image reference will be used if vm_image_id is 'ubuntu' or 'rhel'
   dynamic "source_image_reference" {

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -64,6 +64,17 @@ resource "azurerm_linux_virtual_machine_scale_set" "tfe_vmss" {
     }
   }
 
+  dynamic "source_image_reference" {
+    for_each = var.vm_image_id == null ? [1] : []
+
+    content {
+      publisher = var.vm_image_publisher
+      offer     = var.vm_image_offer
+      sku       = var.vm_image_sku
+      version   = var.vm_image_version
+    }
+  }
+
   admin_ssh_key {
     username   = var.vm_user
     public_key = var.vm_public_key

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -65,7 +65,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "tfe_vmss" {
   }
 
   dynamic "source_image_reference" {
-    for_each = var.vm_image_id == null ? [1] : []
+    for_each = var.vm_image_id == "manual" ? [1] : []
 
     content {
       publisher = var.vm_image_publisher

--- a/modules/vm/variables.tf
+++ b/modules/vm/variables.tf
@@ -107,6 +107,7 @@ variable "vm_image_publisher" {
   vm_image_offer, vm_image_sku, and vm_image_version to determine the image to install from the public markeplace when
   vm_image_id is not provided.
   EOD
+  default = null
 }
 
 variable "vm_image_offer" {
@@ -116,6 +117,7 @@ variable "vm_image_offer" {
   vm_image_publisher, vm_image_sku, and vm_image_version to determine the image to install from the public markeplace
   when vm_image_id is not provided.
   EOD
+  default = null
 }
 
 variable "vm_image_sku" {
@@ -125,6 +127,7 @@ variable "vm_image_sku" {
   vm_image_publisher, vm_image_offer, and vm_image_version to determine the image to install from the public markeplace
   when vm_image_id is not provided.
   EOD
+  default = null
 }
 
 variable "vm_image_version" {
@@ -134,6 +137,7 @@ variable "vm_image_version" {
   vm_image_publisher, vm_image_offer, and vm_image_sku to determine the image to install from the public markeplace
   when vm_image_id is not provided.
   EOD
+  default = null
 }
 
 variable "vm_vmss_scale_in_policy" {

--- a/modules/vm/variables.tf
+++ b/modules/vm/variables.tf
@@ -107,7 +107,7 @@ variable "vm_image_publisher" {
   vm_image_offer, vm_image_sku, and vm_image_version to determine the image to install from the public markeplace when
   vm_image_id is not provided.
   EOD
-  default = null
+  default     = null
 }
 
 variable "vm_image_offer" {
@@ -117,7 +117,7 @@ variable "vm_image_offer" {
   vm_image_publisher, vm_image_sku, and vm_image_version to determine the image to install from the public markeplace
   when vm_image_id is not provided.
   EOD
-  default = null
+  default     = null
 }
 
 variable "vm_image_sku" {
@@ -127,7 +127,7 @@ variable "vm_image_sku" {
   vm_image_publisher, vm_image_offer, and vm_image_version to determine the image to install from the public markeplace
   when vm_image_id is not provided.
   EOD
-  default = null
+  default     = null
 }
 
 variable "vm_image_version" {
@@ -137,7 +137,7 @@ variable "vm_image_version" {
   vm_image_publisher, vm_image_offer, and vm_image_sku to determine the image to install from the public markeplace
   when vm_image_id is not provided.
   EOD
-  default = null
+  default     = null
 }
 
 variable "vm_vmss_scale_in_policy" {

--- a/modules/vm/variables.tf
+++ b/modules/vm/variables.tf
@@ -99,6 +99,42 @@ variable "vm_image_id" {
   }
 }
 
+variable "vm_image_publisher" {
+  type        = string
+  description = <<-EOD
+  The image publisher of the base image to install Terraform Enterprise on.  This is used in conjunction with
+  vm_image_offer, vm_image_sku, and vm_image_version to determine the image to install from the public markeplace when
+  vm_image_id is not provided.
+  EOD
+}
+
+variable "vm_image_offer" {
+  type        = string
+  description = <<-EOD
+  The image offer of the base image to install Terraform Enterprise on.  This is used in conjunction with
+  vm_image_publisher, vm_image_sku, and vm_image_version to determine the image to install from the public markeplace
+  when vm_image_id is not provided.
+  EOD
+}
+
+variable "vm_image_sku" {
+  type        = string
+  description = <<-EOD
+  The image sku of the base image to install Terraform Enterprise on.  This is used in conjunction with
+  vm_image_publisher, vm_image_offer, and vm_image_version to determine the image to install from the public markeplace
+  when vm_image_id is not provided.
+  EOD
+}
+
+variable "vm_image_version" {
+  type        = string
+  description = <<-EOD
+  The image version of the base image to install Terraform Enterprise on.  This is used in conjunction with
+  vm_image_publisher, vm_image_offer, and vm_image_sku to determine the image to install from the public markeplace
+  when vm_image_id is not provided.
+  EOD
+}
+
 variable "vm_vmss_scale_in_policy" {
   description = "The scale-in policy to use for the virtual machine scale set."
   type        = string

--- a/modules/vm/variables.tf
+++ b/modules/vm/variables.tf
@@ -92,10 +92,11 @@ variable "vm_image_id" {
     condition = (
       var.vm_image_id == "ubuntu" ||
       var.vm_image_id == "rhel" ||
+      var.vm_image_id == "manual" ||
       substr(var.vm_image_id, 0, 14) == "/subscriptions"
     )
 
-    error_message = "The vm_image_id value must be 'ubuntu', 'rhel', or an Azure image resource ID beginning with \"/subscriptions\"."
+    error_message = "The vm_image_id value must be 'ubuntu', 'rhel', 'manual', or an Azure image resource ID beginning with \"/subscriptions\"."
   }
 }
 

--- a/tests/standalone-mounted-disk/locals.tf
+++ b/tests/standalone-mounted-disk/locals.tf
@@ -12,31 +12,31 @@ locals {
     var.vm_image_offer != null &&
     var.vm_image_sku != null &&
     var.vm_image_version != null
-    ) ? "manual" : "ubuntu"
+  ) ? "manual" : "ubuntu"
   vm_image_publisher = (
     var.vm_image_publisher != null &&
     var.vm_image_offer != null &&
     var.vm_image_sku != null &&
     var.vm_image_version != null
-    ) ? var.vm_image_publisher : null
+  ) ? var.vm_image_publisher : null
   vm_image_offer = (
     var.vm_image_publisher != null &&
     var.vm_image_offer != null &&
     var.vm_image_sku != null &&
     var.vm_image_version != null
-    ) ? var.vm_image_offer : null
+  ) ? var.vm_image_offer : null
   vm_image_sku = (
     var.vm_image_publisher != null &&
     var.vm_image_offer != null &&
     var.vm_image_sku != null &&
     var.vm_image_version != null
-    ) ? var.vm_image_sku : null
+  ) ? var.vm_image_sku : null
   vm_image_version = (
     var.vm_image_publisher != null &&
     var.vm_image_offer != null &&
     var.vm_image_sku != null &&
     var.vm_image_version != null
-    ) ? var.vm_image_version : null
+  ) ? var.vm_image_version : null
   utility_module_test  = var.license_file == null
   friendly_name_prefix = random_string.friendly_name.id
 }

--- a/tests/standalone-mounted-disk/locals.tf
+++ b/tests/standalone-mounted-disk/locals.tf
@@ -7,7 +7,36 @@ locals {
     Team        = "Terraform Enterprise on Prem"
     OkToDelete  = "True"
   }
-
+  vm_image_id = (
+    var.vm_image_publisher != null &&
+    var.vm_image_offer != null &&
+    var.vm_image_sku != null &&
+    var.vm_image_version != null
+    ) ? "manual" : "ubuntu"
+  vm_image_publisher = (
+    var.vm_image_publisher != null &&
+    var.vm_image_offer != null &&
+    var.vm_image_sku != null &&
+    var.vm_image_version != null
+    ) ? var.vm_image_publisher : null
+  vm_image_offer = (
+    var.vm_image_publisher != null &&
+    var.vm_image_offer != null &&
+    var.vm_image_sku != null &&
+    var.vm_image_version != null
+    ) ? var.vm_image_offer : null
+  vm_image_sku = (
+    var.vm_image_publisher != null &&
+    var.vm_image_offer != null &&
+    var.vm_image_sku != null &&
+    var.vm_image_version != null
+    ) ? var.vm_image_sku : null
+  vm_image_version = (
+    var.vm_image_publisher != null &&
+    var.vm_image_offer != null &&
+    var.vm_image_sku != null &&
+    var.vm_image_version != null
+    ) ? var.vm_image_version : null
   utility_module_test  = var.license_file == null
   friendly_name_prefix = random_string.friendly_name.id
 }

--- a/tests/standalone-mounted-disk/main.tf
+++ b/tests/standalone-mounted-disk/main.tf
@@ -34,7 +34,7 @@ module "standalone_mounted_disk" {
   tls_bootstrap_key_pathname  = "/var/lib/terraform-enterprise/key.pem"
 
   # Standalone Mounted Disk Mode Scenario
-  distribution         = "ubuntu"
+  distribution         = var.distribution
   production_type      = "disk"
   disk_path            = "/opt/hashicorp/data"
   vm_node_count        = 1

--- a/tests/standalone-mounted-disk/main.tf
+++ b/tests/standalone-mounted-disk/main.tf
@@ -39,7 +39,11 @@ module "standalone_mounted_disk" {
   disk_path            = "/opt/hashicorp/data"
   vm_node_count        = 1
   vm_sku               = "Standard_D4_v3"
-  vm_image_id          = "ubuntu"
+  vm_image_id          = local.vm_image_id
+  vm_image_publisher   = local.vm_image_publisher
+  vm_image_offer       = local.vm_image_offer
+  vm_image_sku         = local.vm_image_sku
+  vm_image_version     = local.vm_image_version
   load_balancer_public = true
   load_balancer_type   = "load_balancer"
 

--- a/tests/standalone-mounted-disk/variables.tf
+++ b/tests/standalone-mounted-disk/variables.tf
@@ -26,3 +26,43 @@ variable "tfe_license_secret_id" {
   type        = string
   description = "The Key Vault secret id under which the Base64 encoded Terraform Enterprise license is stored."
 }
+
+variable "vm_image_publisher" {
+  type        = string
+  description = <<-EOD
+  The image publisher of the base image to install Terraform Enterprise on.  This is used in conjunction with
+  vm_image_offer, vm_image_sku, and vm_image_version to determine the image to install from the public markeplace when
+  vm_image_id is not provided.
+  EOD
+  default     = null
+}
+
+variable "vm_image_offer" {
+  type        = string
+  description = <<-EOD
+  The image offer of the base image to install Terraform Enterprise on.  This is used in conjunction with
+  vm_image_publisher, vm_image_sku, and vm_image_version to determine the image to install from the public markeplace
+  when vm_image_id is not provided.
+  EOD
+  default     = null
+}
+
+variable "vm_image_sku" {
+  type        = string
+  description = <<-EOD
+  The image sku of the base image to install Terraform Enterprise on.  This is used in conjunction with
+  vm_image_publisher, vm_image_offer, and vm_image_version to determine the image to install from the public markeplace
+  when vm_image_id is not provided.
+  EOD
+  default     = null
+}
+
+variable "vm_image_version" {
+  type        = string
+  description = <<-EOD
+  The image version of the base image to install Terraform Enterprise on.  This is used in conjunction with
+  vm_image_publisher, vm_image_offer, and vm_image_sku to determine the image to install from the public markeplace
+  when vm_image_id is not provided.
+  EOD
+  default     = null
+}

--- a/tests/standalone-mounted-disk/variables.tf
+++ b/tests/standalone-mounted-disk/variables.tf
@@ -68,6 +68,11 @@ variable "vm_image_version" {
 }
 
 variable "distribution" {
-  type    = string
+  type        = string
+  description = "(Required) What is the OS distribution of the instance on which Terraoform Enterprise will be deployed?"
+  validation {
+    condition     = contains(["rhel", "ubuntu"], var.distribution)
+    error_message = "Supported values for distribution are 'rhel' or 'ubuntu'."
+  }
   default = "ubuntu"
 }

--- a/tests/standalone-mounted-disk/variables.tf
+++ b/tests/standalone-mounted-disk/variables.tf
@@ -66,3 +66,8 @@ variable "vm_image_version" {
   EOD
   default     = null
 }
+
+variable "distribution" {
+  type        = string
+  default     = "ubuntu"
+}

--- a/tests/standalone-mounted-disk/variables.tf
+++ b/tests/standalone-mounted-disk/variables.tf
@@ -68,6 +68,6 @@ variable "vm_image_version" {
 }
 
 variable "distribution" {
-  type        = string
-  default     = "ubuntu"
+  type    = string
+  default = "ubuntu"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -515,6 +515,7 @@ variable "vm_image_id" {
     condition = (
       var.vm_image_id == "ubuntu" ||
       var.vm_image_id == "rhel" ||
+      var.vm_image_id == "manual" ||
       substr(var.vm_image_id, 0, 14) == "/subscriptions"
     )
 

--- a/variables.tf
+++ b/variables.tf
@@ -522,6 +522,42 @@ variable "vm_image_id" {
   }
 }
 
+variable "vm_image_publisher" {
+  type        = string
+  description = <<-EOD
+  The image publisher of the base image to install Terraform Enterprise on.  This is used in conjunction with
+  vm_image_offer, vm_image_sku, and vm_image_version to determine the image to install from the public markeplace when
+  vm_image_id is not provided.
+  EOD
+}
+
+variable "vm_image_offer" {
+  type        = string
+  description = <<-EOD
+  The image offer of the base image to install Terraform Enterprise on.  This is used in conjunction with
+  vm_image_publisher, vm_image_sku, and vm_image_version to determine the image to install from the public markeplace
+  when vm_image_id is not provided.
+  EOD
+}
+
+variable "vm_image_sku" {
+  type        = string
+  description = <<-EOD
+  The image sku of the base image to install Terraform Enterprise on.  This is used in conjunction with
+  vm_image_publisher, vm_image_offer, and vm_image_version to determine the image to install from the public markeplace
+  when vm_image_id is not provided.
+  EOD
+}
+
+variable "vm_image_version" {
+  type        = string
+  description = <<-EOD
+  The image version of the base image to install Terraform Enterprise on.  This is used in conjunction with
+  vm_image_publisher, vm_image_offer, and vm_image_sku to determine the image to install from the public markeplace
+  when vm_image_id is not provided.
+  EOD
+}
+
 variable "vm_sku" {
   default     = "Standard_D4_v3"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -530,7 +530,7 @@ variable "vm_image_publisher" {
   vm_image_offer, vm_image_sku, and vm_image_version to determine the image to install from the public markeplace when
   vm_image_id is not provided.
   EOD
-  default = null
+  default     = null
 }
 
 variable "vm_image_offer" {
@@ -540,7 +540,7 @@ variable "vm_image_offer" {
   vm_image_publisher, vm_image_sku, and vm_image_version to determine the image to install from the public markeplace
   when vm_image_id is not provided.
   EOD
-  default = null
+  default     = null
 }
 
 variable "vm_image_sku" {
@@ -550,7 +550,7 @@ variable "vm_image_sku" {
   vm_image_publisher, vm_image_offer, and vm_image_version to determine the image to install from the public markeplace
   when vm_image_id is not provided.
   EOD
-  default = null
+  default     = null
 }
 
 variable "vm_image_version" {
@@ -560,7 +560,7 @@ variable "vm_image_version" {
   vm_image_publisher, vm_image_offer, and vm_image_sku to determine the image to install from the public markeplace
   when vm_image_id is not provided.
   EOD
-  default = null
+  default     = null
 }
 
 variable "vm_sku" {

--- a/variables.tf
+++ b/variables.tf
@@ -530,6 +530,7 @@ variable "vm_image_publisher" {
   vm_image_offer, vm_image_sku, and vm_image_version to determine the image to install from the public markeplace when
   vm_image_id is not provided.
   EOD
+  default = null
 }
 
 variable "vm_image_offer" {
@@ -539,6 +540,7 @@ variable "vm_image_offer" {
   vm_image_publisher, vm_image_sku, and vm_image_version to determine the image to install from the public markeplace
   when vm_image_id is not provided.
   EOD
+  default = null
 }
 
 variable "vm_image_sku" {
@@ -548,6 +550,7 @@ variable "vm_image_sku" {
   vm_image_publisher, vm_image_offer, and vm_image_version to determine the image to install from the public markeplace
   when vm_image_id is not provided.
   EOD
+  default = null
 }
 
 variable "vm_image_version" {
@@ -557,6 +560,7 @@ variable "vm_image_version" {
   vm_image_publisher, vm_image_offer, and vm_image_sku to determine the image to install from the public markeplace
   when vm_image_id is not provided.
   EOD
+  default = null
 }
 
 variable "vm_sku" {

--- a/variables.tf
+++ b/variables.tf
@@ -519,7 +519,7 @@ variable "vm_image_id" {
       substr(var.vm_image_id, 0, 14) == "/subscriptions"
     )
 
-    error_message = "The vm_image_id value must be 'ubuntu', 'rhel', or an Azure image resource ID beginning with \"/subscriptions\"."
+    error_message = "The vm_image_id value must be 'ubuntu', 'rhel', 'manual', or an Azure image resource ID beginning with \"/subscriptions\"."
   }
 }
 


### PR DESCRIPTION
## Background

This change introduces variables to allow for the selection of arbitrary publicly available base images for TFE beyond the default Ubuntu and RHEL images automatically selected by the module. Often this will be used to select images with particular versions of the target operating system such as RHEL 8.6. The existing procedure for selecting a unique base image is the vm_image_id variable with a setting that begins in `/subscriptions/...`. This image resource url, as far as I can tell, is only suitable for privately hosted images. 


## How Has This Been Tested

This change has been tested manually by generating default RHEL and a host of RHEL 8 images. These instances were hit with a standard TFE smoke test. This change relies on [this change](https://github.com/hashicorp/terraform-random-tfe-utility/pull/78) in order to test RHEL 8 instances successfully.  `/test all` will be executed prior to merging.

## This PR makes me feel

<img src="https://media4.giphy.com/media/POHFlqzSFsakigiBlH/giphy.gif"/>
