### PR TITLE
Enabling passthrough config for tfe metrics

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -180,6 +180,11 @@ module "settings" {
   azure_account_key  = local.object_storage.storage_account_key
   azure_account_name = local.object_storage.storage_account_name
   azure_container    = local.object_storage.storage_account_container_name
+
+  # Metrics
+  metrics_endpoint_enabled    = var.metrics_endpoint_enabled
+  metrics_endpoint_port_http  = var.metrics_endpoint_port_http
+  metrics_endpoint_port_https = var.metrics_endpoint_port_https
 }
 
 # -----------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -802,6 +802,36 @@ variable "iact_subnet_list" {
   type        = list(string)
 }
 
+variable "metrics_endpoint_enabled" {
+  default     = null
+  type        = bool
+  description = <<-EOD
+  (Optional) Metrics are used to understand the behavior of Terraform Enterprise and to
+  troubleshoot and tune performance. Enable an endpoint to expose container metrics.
+  Defaults to false.
+  EOD
+}
+
+variable "metrics_endpoint_port_http" {
+  default     = null
+  type        = number
+  description = <<-EOD
+  (Optional when metrics_endpoint_enabled is true.) Defines the TCP port on which HTTP metrics
+  requests will be handled.
+  Defaults to 9090.
+  EOD
+}
+
+variable "metrics_endpoint_port_https" {
+  default     = null
+  type        = string
+  description = <<-EOD
+  (Optional when metrics_endpoint_enabled is true.) Defines the TCP port on which HTTPS metrics
+  requests will be handled.
+  Defaults to 9091.
+  EOD
+}
+
 variable "tbw_image" {
   default     = null
   type        = string


### PR DESCRIPTION
## Background

This change enables TFE metrics and increases cloud parity across the 3 major cloud estates.

## How Has This Been Tested

This change will be tested with standard /test commands.

## This PR makes me feel

<img src="https://media2.giphy.com/media/3og0IExSrnfW2kUaaI/giphy.gif"/>
