### PR TITLE
removed provider from all examples

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -36,10 +36,6 @@ rule "terraform_required_version" {
   enabled = true
 }
 
-rule "terraform_required_providers" {
-  enabled = true
-}
-
 rule "terraform_unused_required_providers" {
   enabled = true
 }

--- a/examples/active-active-proxy/versions.tf
+++ b/examples/active-active-proxy/versions.tf
@@ -11,7 +11,3 @@ terraform {
     }
   }
 }
-
-provider "azurerm" {
-  features {}
-}

--- a/examples/active-active-proxy/versions.tf
+++ b/examples/active-active-proxy/versions.tf
@@ -1,10 +1,6 @@
 terraform {
   required_version = "~> 1.0"
   required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 3.2"
-    }
     random = {
       source  = "hashicorp/random"
       version = "~> 3.1"

--- a/examples/existing-network/versions.tf
+++ b/examples/existing-network/versions.tf
@@ -11,6 +11,3 @@ terraform {
     }
   }
 }
-provider "azurerm" {
-  features {}
-}

--- a/examples/existing-network/versions.tf
+++ b/examples/existing-network/versions.tf
@@ -1,10 +1,6 @@
 terraform {
   required_version = "~> 1.0"
   required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 3.2"
-    }
     random = {
       source  = "hashicorp/random"
       version = "~> 3.1"

--- a/examples/standalone_airgap/versions.tf
+++ b/examples/standalone_airgap/versions.tf
@@ -11,8 +11,3 @@ terraform {
     }
   }
 }
-
-provider "azurerm" {
-  features {}
-}
-

--- a/examples/standalone_airgap/versions.tf
+++ b/examples/standalone_airgap/versions.tf
@@ -1,10 +1,6 @@
 terraform {
   required_version = "~> 1.0"
   required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 3.2"
-    }
     random = {
       source  = "hashicorp/random"
       version = "~> 3.1"

--- a/examples/standalone_airgap_dev/versions.tf
+++ b/examples/standalone_airgap_dev/versions.tf
@@ -12,7 +12,3 @@ terraform {
   }
 }
 
-provider "azurerm" {
-  features {}
-}
-

--- a/examples/standalone_airgap_dev/versions.tf
+++ b/examples/standalone_airgap_dev/versions.tf
@@ -1,10 +1,6 @@
 terraform {
   required_version = "~> 1.0"
   required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 3.2"
-    }
     random = {
       source  = "hashicorp/random"
       version = "~> 3.1"

--- a/examples/standalone_mounted_disk/versions.tf
+++ b/examples/standalone_mounted_disk/versions.tf
@@ -12,7 +12,3 @@ terraform {
   }
 }
 
-provider "azurerm" {
-  features {}
-}
-

--- a/examples/standalone_mounted_disk/versions.tf
+++ b/examples/standalone_mounted_disk/versions.tf
@@ -1,10 +1,6 @@
 terraform {
   required_version = "~> 1.0"
   required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 3.2"
-    }
     random = {
       source  = "hashicorp/random"
       version = "~> 3.1"


### PR DESCRIPTION
## Background

[A module intended to be called by one or more other modules must not contain any provider](https://www.terraform.io/language/modules/develop/providers#:~:text=A%20module%20intended%20to%20be%20called%20by%20one%20or%20more%20other%20modules%20must%20not%20contain%20any%20provider)
I have removed [terraform_required_providers](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/pull/185/commits/8ec61fb7898be4be63f464dffe7fb6294605a919) from tflint rules - > This is not required in child modules ([causing issues when invoked externally in all clouds](https://tfe.hashicorp.engineering/app/ptfe/workspaces/sandra-user-workspace/runs/run-gCb4DoTKicTJ27Rj)) and is only applicable if you are running terraform in root

For this PR, provider blocks are removed only from the examples.
