### PR TITLE
add a postgres version variable defaulted to 12

### DIFF
--- a/tests/standalone-external/main.tf
+++ b/tests/standalone-external/main.tf
@@ -34,6 +34,7 @@ module "standalone_external" {
 
   # Standalone External Scenario
   distribution         = "ubuntu"
+  database_version     = var.database_version
   production_type      = "external"
   iact_subnet_list     = ["0.0.0.0/0"]
   vm_node_count        = 1

--- a/tests/standalone-external/variables.tf
+++ b/tests/standalone-external/variables.tf
@@ -16,6 +16,12 @@ variable "license_file" {
   description = "The local path to the Terraform Enterprise license to be provided by CI."
 }
 
+variable "database_version" {
+  default     = 12
+  type        = number
+  description = "Postgres version"
+}
+
 variable "resource_group_name_dns" {
   type        = string
   default     = "ptfedev-com-dns-tls"


### PR DESCRIPTION
## Background

[Asana](https://app.asana.com/0/1203008725756147/1203052402119121/f)

In order to add a Postgres 11 test to the nightlies, we'll need for this module to have a variable for the Postgres version.