### PR TITLE
fix typo in workflow branch name

### DIFF
--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -9,5 +9,5 @@ on:
 
 jobs:
   create-jira-issue:
-    uses: hashicorp/tf-enterprise-workflows/.github/workflows/create-jira-issue.yml@vmain
+    uses: hashicorp/tf-enterprise-workflows/.github/workflows/create-jira-issue.yml@main
     secrets: inherit


### PR DESCRIPTION
## Background

Whoops - I had a typo in the branch name. 