### PR TITLE
Add Option for tunneling in Bastion Host

### DIFF
--- a/modules/bastion/main.tf
+++ b/modules/bastion/main.tf
@@ -13,6 +13,9 @@ resource "azurerm_bastion_host" "bastion_host" {
   location            = var.location
   resource_group_name = var.resource_group_name
 
+  sku               = var.bastion_sku
+  tunneling_enabled = var.bastion_tunneling_enabled
+
   ip_configuration {
     name                 = "tfebastion"
     subnet_id            = var.bastion_subnet_id

--- a/modules/bastion/variables.tf
+++ b/modules/bastion/variables.tf
@@ -34,7 +34,13 @@ variable "bastion_allocation_method" {
 variable "bastion_sku" {
   default     = "Standard"
   type        = string
-  description = "The SKU of the Public IP. Accepted values are Basic and Standard"
+  description = "The SKU of the Public IP and Host. Accepted values are Basic and Standard"
+}
+
+variable "bastion_tunneling_enabled" {
+  default     = true
+  type        = bool
+  description = "Is Tunneling feature enabled for the Bastion Host."
 }
 
 # Tagging


### PR DESCRIPTION
## Background

We would like to use Azure CLI to connect to VMs and not using SSH over a web browser. This needs tunneling enabled and this needs the SKU standard.

