### PR TITLE
updating the latest rhel image to 8.7

### DIFF
--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -62,8 +62,8 @@ resource "azurerm_linux_virtual_machine_scale_set" "tfe_vmss" {
     content {
       publisher = var.vm_image_id == "ubuntu" ? "Canonical" : "RedHat"
       offer     = var.vm_image_id == "ubuntu" ? "0001-com-ubuntu-server-focal" : "RHEL"
-      sku       = var.vm_image_id == "ubuntu" ? "20_04-lts" : "7.8"
-      version   = var.vm_image_id == "ubuntu" ? "latest" : "latest"
+      sku       = var.vm_image_id == "ubuntu" ? "20_04-lts" : "8_7"
+      version   = var.vm_image_id == "ubuntu" ? "latest" : "8.7.2023022801"
     }
   }
 

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -63,7 +63,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "tfe_vmss" {
       publisher = var.vm_image_id == "ubuntu" ? "Canonical" : "RedHat"
       offer     = var.vm_image_id == "ubuntu" ? "0001-com-ubuntu-server-focal" : "RHEL"
       sku       = var.vm_image_id == "ubuntu" ? "20_04-lts" : "8_7"
-      version   = var.vm_image_id == "ubuntu" ? "latest" : "8.7.2023022801"
+      version   = var.vm_image_id == "ubuntu" ? "latest" : "latest"
     }
   }
 

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -63,7 +63,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "tfe_vmss" {
       publisher = var.vm_image_id == "ubuntu" ? "Canonical" : "RedHat"
       offer     = var.vm_image_id == "ubuntu" ? "0001-com-ubuntu-server-focal" : "RHEL"
       sku       = var.vm_image_id == "ubuntu" ? "20_04-lts" : "8_7"
-      version   = var.vm_image_id == "ubuntu" ? "latest" : "latest"
+      version   = var.vm_image_id == "ubuntu" ? "latest" : "8.7.2023022801"
     }
   }
 


### PR DESCRIPTION
## Background

This change updates the default rhel image to 8.7 targeting the most recent available image at the time of writing.

## How Has This Been Tested

/test tests

