### PR TITLE
Fix Deprecation in Virtual Machine Scale Set

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -287,32 +287,33 @@ module "vm" {
   tenant_id            = data.azurerm_client_config.current.tenant_id
 
   # VM
-  disk_mode                         = local.disk_mode
-  vm_data_disk_caching              = var.vm_data_disk_caching
-  vm_data_disk_create_option        = var.vm_data_disk_create_option
-  vm_data_disk_disk_size_gb         = var.vm_data_disk_disk_size_gb
-  vm_data_disk_lun                  = var.vm_data_disk_lun
-  vm_data_disk_storage_account_type = var.vm_data_disk_storage_account_type
-  vm_identity_type                  = var.vm_identity_type
-  vm_image_id                       = var.vm_image_id
-  vm_image_publisher                = var.vm_image_publisher
-  vm_image_offer                    = var.vm_image_offer
-  vm_image_sku                      = var.vm_image_sku
-  vm_image_version                  = var.vm_image_version
-  vm_node_count                     = var.vm_node_count
-  vm_os_disk_caching                = var.vm_os_disk_caching
-  vm_os_disk_disk_size_gb           = var.vm_os_disk_disk_size_gb
-  vm_os_disk_storage_account_type   = var.vm_os_disk_storage_account_type
-  vm_overprovision                  = var.vm_overprovision
-  vm_public_key                     = var.vm_public_key == null ? tls_private_key.tfe_ssh[0].public_key_openssh : var.vm_public_key
-  vm_sku                            = var.vm_sku
-  vm_subnet_id                      = local.network.private_subnet.id
-  vm_upgrade_mode                   = var.vm_upgrade_mode
-  vm_user                           = var.vm_user
-  vm_userdata_script                = module.tfe_init.tfe_userdata_base64_encoded
-  vm_vmss_scale_in_policy           = var.vm_vmss_scale_in_policy
-  vm_zone_balance                   = var.vm_zone_balance
-  zones                             = var.zones
+  disk_mode                               = local.disk_mode
+  vm_data_disk_caching                    = var.vm_data_disk_caching
+  vm_data_disk_create_option              = var.vm_data_disk_create_option
+  vm_data_disk_disk_size_gb               = var.vm_data_disk_disk_size_gb
+  vm_data_disk_lun                        = var.vm_data_disk_lun
+  vm_data_disk_storage_account_type       = var.vm_data_disk_storage_account_type
+  vm_identity_type                        = var.vm_identity_type
+  vm_image_id                             = var.vm_image_id
+  vm_image_publisher                      = var.vm_image_publisher
+  vm_image_offer                          = var.vm_image_offer
+  vm_image_sku                            = var.vm_image_sku
+  vm_image_version                        = var.vm_image_version
+  vm_node_count                           = var.vm_node_count
+  vm_os_disk_caching                      = var.vm_os_disk_caching
+  vm_os_disk_disk_size_gb                 = var.vm_os_disk_disk_size_gb
+  vm_os_disk_storage_account_type         = var.vm_os_disk_storage_account_type
+  vm_overprovision                        = var.vm_overprovision
+  vm_public_key                           = var.vm_public_key == null ? tls_private_key.tfe_ssh[0].public_key_openssh : var.vm_public_key
+  vm_sku                                  = var.vm_sku
+  vm_subnet_id                            = local.network.private_subnet.id
+  vm_upgrade_mode                         = var.vm_upgrade_mode
+  vm_user                                 = var.vm_user
+  vm_userdata_script                      = module.tfe_init.tfe_userdata_base64_encoded
+  vm_vmss_scale_in_rule                   = var.vm_vmss_scale_in_rule
+  vm_vmss_scale_in_force_deletion_enabled = var.vm_vmss_scale_in_force_deletion_enabled
+  vm_zone_balance                         = var.vm_zone_balance
+  zones                                   = var.zones
 
   # Load balancer
   load_balancer_type       = var.load_balancer_type

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -33,11 +33,10 @@ resource "azurerm_linux_virtual_machine_scale_set" "tfe_vmss" {
   location            = var.location
   resource_group_name = var.resource_group_name
 
-  overprovision   = var.vm_overprovision
-  instances       = var.vm_node_count
-  sku             = var.vm_sku
-  admin_username  = var.vm_user
-  scale_in_policy = var.vm_vmss_scale_in_policy
+  overprovision  = var.vm_overprovision
+  instances      = var.vm_node_count
+  sku            = var.vm_sku
+  admin_username = var.vm_user
 
   upgrade_mode = var.vm_upgrade_mode
 
@@ -54,6 +53,11 @@ resource "azurerm_linux_virtual_machine_scale_set" "tfe_vmss" {
 
   # Source image id will be used if vm_image_id anything other than 'ubuntu' or 'rhel'
   source_image_id = var.vm_image_id == "ubuntu" || var.vm_image_id == "rhel" || var.vm_image_id == "manual" ? null : var.vm_image_id
+
+  scale_in {
+    rule                   = var.vm_vmss_scale_in_rule
+    force_deletion_enabled = var.vm_vmss_scale_in_force_deletion_enabled
+  }
 
   # Source image reference will be used if vm_image_id is 'ubuntu' or 'rhel'
   dynamic "source_image_reference" {

--- a/modules/vm/variables.tf
+++ b/modules/vm/variables.tf
@@ -144,7 +144,6 @@ variable "vm_image_version" {
 }
 
 variable "vm_vmss_scale_in_rule" {
-  default     = "Default"
   type        = string
   description = "The scale-in rule to use for the virtual machine scale set."
 
@@ -160,7 +159,6 @@ variable "vm_vmss_scale_in_rule" {
 }
 
 variable "vm_vmss_scale_in_force_deletion_enabled" {
-  default     = false
   type        = bool
   description = "Should the virtual machines chosen for removal be force deleted when the virtual machine scale set is being scaled-in?"
 }

--- a/modules/vm/variables.tf
+++ b/modules/vm/variables.tf
@@ -143,19 +143,26 @@ variable "vm_image_version" {
   default     = null
 }
 
-variable "vm_vmss_scale_in_policy" {
-  description = "The scale-in policy to use for the virtual machine scale set."
+variable "vm_vmss_scale_in_rule" {
+  default     = "Default"
   type        = string
+  description = "The scale-in rule to use for the virtual machine scale set."
 
   validation {
     condition = (
-      var.vm_vmss_scale_in_policy == "Default" ||
-      var.vm_vmss_scale_in_policy == "NewestVM" ||
-      var.vm_vmss_scale_in_policy == "OldestVM"
+      var.vm_vmss_scale_in_rule == "Default" ||
+      var.vm_vmss_scale_in_rule == "NewestVM" ||
+      var.vm_vmss_scale_in_rule == "OldestVM"
     )
 
     error_message = "The vm_vmss_scale_in_policy value must be 'Default', 'NewestVM', or 'OldestVM'."
   }
+}
+
+variable "vm_vmss_scale_in_force_deletion_enabled" {
+  default     = false
+  type        = bool
+  description = "Should the virtual machines chosen for removal be force deleted when the virtual machine scale set is being scaled-in?"
 }
 
 variable "ca_certificate_secret" {

--- a/variables.tf
+++ b/variables.tf
@@ -578,20 +578,26 @@ variable "vm_os_disk_disk_size_gb" {
   description = "The size of the OS Disk which should be created"
 }
 
-variable "vm_vmss_scale_in_policy" {
+variable "vm_vmss_scale_in_rule" {
   default     = "Default"
   type        = string
-  description = "The scale-in policy to use for the virtual machine scale set."
+  description = "The scale-in rule to use for the virtual machine scale set."
 
   validation {
     condition = (
-      var.vm_vmss_scale_in_policy == "Default" ||
-      var.vm_vmss_scale_in_policy == "NewestVM" ||
-      var.vm_vmss_scale_in_policy == "OldestVM"
+      var.vm_vmss_scale_in_rule == "Default" ||
+      var.vm_vmss_scale_in_rule == "NewestVM" ||
+      var.vm_vmss_scale_in_rule == "OldestVM"
     )
 
     error_message = "The vm_vmss_scale_in_policy value must be 'Default', 'NewestVM', or 'OldestVM'."
   }
+}
+
+variable "vm_vmss_scale_in_force_deletion_enabled" {
+  default     = false
+  type        = bool
+  description = "Should the virtual machines chosen for removal be force deleted when the virtual machine scale set is being scaled-in?"
 }
 
 variable "vm_overprovision" {


### PR DESCRIPTION
## Background

This change will fix a deprecation in `azurerm_linux_virtual_machine_scale_set`:

```
│ Warning: Argument is deprecated
│ 
│   with module.vm.azurerm_linux_virtual_machine_scale_set.tfe_vmss,
│   on modules/vm/main.tf line 40, in resource "azurerm_linux_virtual_machine_scale_set" "tfe_vmss":
│   40:   scale_in_policy = var.vm_vmss_scale_in_policy
│ 
│ `scale_in_policy` will be removed in favour of the `scale_in` code block in
│ version 4.0 of the AzureRM Provider.
```

It replaces `var.scale_in_policy` with two new variables:

- `var.vm_vmss_scale_in_rule` (default: `"Default"`)
- `vm_vmss_scale_in_force_deletion_enabled` (default: `false`)
