### PR TITLE
add hairpin_addressing variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -143,6 +143,7 @@ module "settings" {
   custom_image_tag       = var.custom_image_tag
   custom_agent_image_tag = var.custom_agent_image_tag
   disk_path              = var.disk_path
+  hairpin_addressing     = var.hairpin_addressing
   iact_subnet_list       = var.iact_subnet_list
   pg_extra_params        = var.pg_extra_params
   production_type        = var.production_type

--- a/variables.tf
+++ b/variables.tf
@@ -764,6 +764,17 @@ variable "custom_image_tag" {
   EOD
 }
 
+variable "hairpin_addressing" {
+  default     = null
+  type        = bool
+  description = <<-EOD
+  In some cloud environments, HTTP clients running on instances behind a loadbalancer cannot send
+  requests to the public hostname of that load balancer. Use this setting to configure TFE services
+  to redirect requests for the installation's FQDN to the instance'sinternal IP address.
+  Defaults to false.
+  EOD
+}
+
 variable "tfe_license_file_location" {
   default     = "/etc/terraform-enterprise.rli"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -770,7 +770,7 @@ variable "hairpin_addressing" {
   description = <<-EOD
   In some cloud environments, HTTP clients running on instances behind a loadbalancer cannot send
   requests to the public hostname of that load balancer. Use this setting to configure TFE services
-  to redirect requests for the installation's FQDN to the instance'sinternal IP address.
+  to redirect requests for the installation's FQDN to the instance's internal IP address.
   Defaults to false.
   EOD
 }


### PR DESCRIPTION
## Background

While testing locally, I discovered that hairpinning is not added as a variable. This adds the variable so that it can be added as a setting. 

[TF-5772](https://hashicorp.atlassian.net/browse/TF-5772)

Relates OR Closes #0000


## How Has This Been Tested

Tested locally. This variable is not added to the tests.

[TF-5772]: https://hashicorp.atlassian.net/browse/TF-5772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ