### PR TITLE
update standalone test providers

### DIFF
--- a/tests/standalone-external/versions.tf
+++ b/tests/standalone-external/versions.tf
@@ -2,6 +2,14 @@
 # SPDX-License-Identifier: MPL-2.0
 
 terraform {
+  backend "remote" {
+    organization = "terraform-enterprise-modules-test"
+
+    workspaces {
+      name = "azure-standalone-external"
+    }
+  }
+
   required_version = "~> 1.0"
   required_providers {
     azurerm = {

--- a/tests/standalone-mounted-disk/versions.tf
+++ b/tests/standalone-mounted-disk/versions.tf
@@ -2,6 +2,14 @@
 # SPDX-License-Identifier: MPL-2.0
 
 terraform {
+  backend "remote" {
+    organization = "terraform-enterprise-modules-test"
+
+    workspaces {
+      name = "azure-standalone-mounted-disk"
+    }
+  }
+
   required_version = "~> 1.0"
   required_providers {
     azurerm = {


### PR DESCRIPTION
## Background

https://hashicorp.atlassian.net/browse/TF-8610

This branch seeks to make use of the two unused but created workspaces for standalone tests [here](https://github.com/hashicorp/ptfedev-infra/blob/main/tfe-module-ci-backend/azure-standalone-mounted-disk.tf) and [here](https://github.com/hashicorp/ptfedev-infra/blob/main/tfe-module-ci-backend/azure-standalone-external.tf). It hardcodes the providers to use the providers for the workspaces that test the repository's tests. 

It will be tested in subsequent pull requests as I'm working out the test workflow in another branch.