### PR TITLE
pin workflows

### DIFF
--- a/.github/workflows/handler-destroy.yml
+++ b/.github/workflows/handler-destroy.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   azure_public_active_active:
-    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-destroy.yml
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-destroy.yml@main
     secrets: inherit
     name: Destroy resources from Azure Public Active/Active
     if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'azure-public-active-active') }}
@@ -22,7 +22,7 @@ jobs:
       TFC_token_secret_name: PUBLIC_ACTIVE_ACTIVE_TFC_TOKEN
 
   azure_private_active_active:
-    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-destroy.yml
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-destroy.yml@main
     secrets: inherit
     name: Destroy resources from Azure Private Active/Active
     if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'azure-private-active-active') }}
@@ -37,7 +37,7 @@ jobs:
       TFC_token_secret_name: PRIVATE_ACTIVE_ACTIVE_TFC_TOKEN
 
   azure_private_tcp_active_active:
-    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-destroy.yml
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-destroy.yml@main
     secrets: inherit
     name: Destroy resources from Azure Private TCP Active/Active
     if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'azure-private-tcp-active-active') }}
@@ -52,7 +52,7 @@ jobs:
       TFC_token_secret_name: PRIVATE_TCP_ACTIVE_ACTIVE_TFC_TOKEN
 
   azure_standalone_external:
-    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-destroy.yml
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-destroy.yml@main
     secrets: inherit
     name: Destroy resources from Azure Standalone External
     if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'azure-standalone-external') }}
@@ -74,7 +74,7 @@ jobs:
         }\n/'
 
   azure_standalone_mounted_disk:
-    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-destroy.yml
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-destroy.yml@main
     secrets: inherit
     name: Destroy resources from Azure Standalone Mounted Disk
     if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'azure-standalone-mounted-disk') }}

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   standalone_external:
-    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-tests.yml
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-tests.yml@main
     secrets: inherit
     name: Run tf-test on Azure Standalone External
     if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'standalone-external') }}
@@ -30,7 +30,7 @@ jobs:
         }\n/'
 
   standalone_mounted_disk:
-    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-tests.yml
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-tests.yml@main
     secrets: inherit
     name: Run tf-test on Azure Standalone Mounted Disk
     if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'standalone-mounted-disk') }}
@@ -53,7 +53,7 @@ jobs:
         }\n/'
 
   public_active_active:
-    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-tests.yml
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-tests.yml@main
     secrets: inherit
     name: Run tf-test on Azure Public Active/Active
     if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'public-active-active') }}
@@ -70,7 +70,7 @@ jobs:
       TFC_workspace_substitution_pattern: s/azure-public-active-active/azure-public-active-active/
   
   private_active_active:
-    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-tests.yml
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-tests.yml@main
     secrets: inherit
     name: Run tf-test on Azure Private Active/Active
     if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-active-active') }}
@@ -88,7 +88,7 @@ jobs:
       bastion_ssh_private_key_secret_name: PRIVATE_ACTIVE_ACTIVE_BASTION_SSH_KEY_BASE64
 
   private_tcp_active_active:
-    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-tests.yml
+    uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-tests.yml@main
     secrets: inherit
     name: Run tf-test on Azure Private TCP Active/Active
     if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-tcp-active-active') }}


### PR DESCRIPTION
## Background

#220 introduced the reusable workflows, however, they should have been pinned in order to avoid [this error](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/actions/runs/6101642222/workflow). This is an [example](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-of-jobsjob_idwith) in the docs.


## How Has This Been Tested

Must be tested post-merge in a new PR.