### PR TITLE
replace consolidated_services variable with consolidated_services_enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -223,16 +223,16 @@ module "settings" {
   count  = var.is_replicated_deployment ? 1 : 0
 
   # TFE Base Configuration
-  consolidated_services  = var.consolidated_services
-  custom_image_tag       = var.custom_image_tag
-  custom_agent_image_tag = var.custom_agent_image_tag
-  disk_path              = var.disk_path
-  hairpin_addressing     = var.hairpin_addressing
-  iact_subnet_list       = var.iact_subnet_list
-  pg_extra_params        = var.pg_extra_params
-  production_type        = var.production_type
-  release_sequence       = var.release_sequence
-  trusted_proxies        = local.trusted_proxies
+  consolidated_services_enabled = var.consolidated_services_enabled
+  custom_image_tag              = var.custom_image_tag
+  custom_agent_image_tag        = var.custom_agent_image_tag
+  disk_path                     = var.disk_path
+  hairpin_addressing            = var.hairpin_addressing
+  iact_subnet_list              = var.iact_subnet_list
+  pg_extra_params               = var.pg_extra_params
+  production_type               = var.production_type
+  release_sequence              = var.release_sequence
+  trusted_proxies               = local.trusted_proxies
 
   extra_no_proxy = [
     "127.0.0.1",

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -63,7 +63,7 @@ module "private_active_active" {
   proxy_port = local.proxy_port
 
   # Private Active / Active Scenario
-  consolidated_services              = var.consolidated_services
+  consolidated_services_enabled      = var.consolidated_services_enabled
   distribution                       = "rhel"
   vm_node_count                      = 2
   vm_sku                             = "Standard_D16as_v4"

--- a/tests/private-active-active/variables.tf
+++ b/tests/private-active-active/variables.tf
@@ -6,7 +6,7 @@ variable "bastion_public_ssh_key_secret_name" {
   description = "The name of the public SSH key secret for the bastion."
 }
 
-variable "consolidated_services" {
+variable "consolidated_services_enabled" {
   default     = false
   type        = bool
   description = "(Required) True if TFE uses consolidated services."

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -65,18 +65,18 @@ module "private_tcp_active_active" {
   proxy_port            = local.proxy_port
 
   # Private Active / Active Scenario
-  consolidated_services      = var.consolidated_services
-  distribution               = "rhel"
-  vm_node_count              = 2
-  vm_sku                     = "Standard_D32a_v4"
-  vm_image_id                = "rhel"
-  load_balancer_public       = false
-  load_balancer_type         = "load_balancer"
-  redis_use_password_auth    = true
-  redis_use_tls              = true
-  redis_rdb_backup_enabled   = true
-  redis_rdb_backup_frequency = 60
-  production_type            = "external"
+  consolidated_services_enabled = var.consolidated_services_enabled
+  distribution                  = "rhel"
+  vm_node_count                 = 2
+  vm_sku                        = "Standard_D32a_v4"
+  vm_image_id                   = "rhel"
+  load_balancer_public          = false
+  load_balancer_type            = "load_balancer"
+  redis_use_password_auth       = true
+  redis_use_tls                 = true
+  redis_rdb_backup_enabled      = true
+  redis_rdb_backup_frequency    = 60
+  production_type               = "external"
 
   create_bastion = false
   tags           = local.common_tags

--- a/tests/private-tcp-active-active/variables.tf
+++ b/tests/private-tcp-active-active/variables.tf
@@ -16,7 +16,7 @@ variable "ca_key_secret_name" {
   description = "The name of a Key Vault secret which contains the Base64 encoded version of a PEM encoded private key of a certificate authority (CA)."
 }
 
-variable "consolidated_services" {
+variable "consolidated_services_enabled" {
   default     = false
   type        = bool
   description = "(Required) True if TFE uses consolidated services."

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -25,17 +25,17 @@ module "public_active_active" {
   tls_bootstrap_key_pathname  = "/var/lib/terraform-enterprise/key.pem"
 
   # Public Active / Active Scenario
-  consolidated_services   = var.consolidated_services
-  distribution            = "ubuntu"
-  production_type         = "external"
-  iact_subnet_list        = var.iact_subnet_list
-  vm_node_count           = 2
-  vm_sku                  = "Standard_D4_v3"
-  vm_image_id             = "ubuntu"
-  load_balancer_public    = true
-  load_balancer_type      = "application_gateway"
-  redis_use_password_auth = false
-  redis_use_tls           = false
+  consolidated_services_enabled = var.consolidated_services_enabled
+  distribution                  = "ubuntu"
+  production_type               = "external"
+  iact_subnet_list              = var.iact_subnet_list
+  vm_node_count                 = 2
+  vm_sku                        = "Standard_D4_v3"
+  vm_image_id                   = "ubuntu"
+  load_balancer_public          = true
+  load_balancer_type            = "application_gateway"
+  redis_use_password_auth       = false
+  redis_use_tls                 = false
 
   tags = local.common_tags
 

--- a/tests/public-active-active/variables.tf
+++ b/tests/public-active-active/variables.tf
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-variable "consolidated_services" {
+variable "consolidated_services_enabled" {
   default     = false
   type        = bool
   description = "(Required) True if TFE uses consolidated services."

--- a/tests/standalone-external/main.tf
+++ b/tests/standalone-external/main.tf
@@ -38,16 +38,16 @@ module "standalone_external" {
   custom_agent_image_tag      = "hashicorp/tfc-agent:latest"
 
   # Standalone External Scenario
-  consolidated_services = var.consolidated_services
-  distribution          = "ubuntu"
-  database_version      = var.database_version
-  production_type       = "external"
-  iact_subnet_list      = ["0.0.0.0/0"]
-  vm_node_count         = 1
-  vm_sku                = "Standard_D4_v3"
-  vm_image_id           = "ubuntu"
-  load_balancer_public  = true
-  load_balancer_type    = "load_balancer"
+  consolidated_services_enabled = var.consolidated_services_enabled
+  distribution                  = "ubuntu"
+  database_version              = var.database_version
+  production_type               = "external"
+  iact_subnet_list              = ["0.0.0.0/0"]
+  vm_node_count                 = 1
+  vm_sku                        = "Standard_D4_v3"
+  vm_image_id                   = "ubuntu"
+  load_balancer_public          = true
+  load_balancer_type            = "load_balancer"
 
   enable_ssh     = true
   create_bastion = false

--- a/tests/standalone-external/variables.tf
+++ b/tests/standalone-external/variables.tf
@@ -7,7 +7,7 @@ variable "bypass_preflight_checks" {
   description = "Allow the TFE application to start without preflight checks."
 }
 
-variable "consolidated_services" {
+variable "consolidated_services_enabled" {
   default     = false
   type        = bool
   description = "(Required) True if TFE uses consolidated services."

--- a/tests/standalone-mounted-disk/main.tf
+++ b/tests/standalone-mounted-disk/main.tf
@@ -38,19 +38,19 @@ module "standalone_mounted_disk" {
   bypass_preflight_checks     = var.bypass_preflight_checks
 
   # Standalone Mounted Disk Mode Scenario
-  consolidated_services = var.consolidated_services
-  distribution          = var.distribution
-  production_type       = "disk"
-  disk_path             = "/opt/hashicorp/data"
-  vm_node_count         = 1
-  vm_sku                = "Standard_D4_v3"
-  vm_image_id           = local.vm_image_id
-  vm_image_publisher    = local.vm_image_publisher
-  vm_image_offer        = local.vm_image_offer
-  vm_image_sku          = local.vm_image_sku
-  vm_image_version      = local.vm_image_version
-  load_balancer_public  = true
-  load_balancer_type    = "load_balancer"
+  consolidated_services_enabled = var.consolidated_services_enabled
+  distribution                  = var.distribution
+  production_type               = "disk"
+  disk_path                     = "/opt/hashicorp/data"
+  vm_node_count                 = 1
+  vm_sku                        = "Standard_D4_v3"
+  vm_image_id                   = local.vm_image_id
+  vm_image_publisher            = local.vm_image_publisher
+  vm_image_offer                = local.vm_image_offer
+  vm_image_sku                  = local.vm_image_sku
+  vm_image_version              = local.vm_image_version
+  load_balancer_public          = true
+  load_balancer_type            = "load_balancer"
 
   # VM Data Disk
   vm_data_disk_caching              = "ReadWrite"

--- a/tests/standalone-mounted-disk/variables.tf
+++ b/tests/standalone-mounted-disk/variables.tf
@@ -8,7 +8,7 @@ variable "bypass_preflight_checks" {
   description = "Allow the TFE application to start without preflight checks."
 }
 
-variable "consolidated_services" {
+variable "consolidated_services_enabled" {
   default     = false
   type        = bool
   description = "(Required) True if TFE uses consolidated services."

--- a/variables.tf
+++ b/variables.tf
@@ -799,7 +799,7 @@ variable "capacity_memory" {
   description = "The maximum amount of memory (in megabytes) that a Terraform plan or apply can use on the system; defaults to `512` for replicated mode and `2048` for FDO."
 }
 
-variable "consolidated_services" {
+variable "consolidated_services_enabled" {
   default     = false
   type        = bool
   description = "(Required if var.is_replicated_deployment is true) True if TFE uses consolidated services."


### PR DESCRIPTION
## Background

This updates the module to use the `consolidated_services_enabled` variable since it was changed in [this merge](https://github.com/hashicorp/ptfe-replicated/pull/1734) to `ptfe-replicated`.

## How Has This Been Tested

I tested this locally and will test in `ptfe-replicated` post merge.