### PR TITLE
default consolidated_services_enabled to true

### DIFF
--- a/tests/private-active-active/variables.tf
+++ b/tests/private-active-active/variables.tf
@@ -7,7 +7,7 @@ variable "bastion_public_ssh_key_secret_name" {
 }
 
 variable "consolidated_services_enabled" {
-  default     = false
+  default     = true
   type        = bool
   description = "(Required) True if TFE uses consolidated services."
 }

--- a/tests/private-tcp-active-active/variables.tf
+++ b/tests/private-tcp-active-active/variables.tf
@@ -17,7 +17,7 @@ variable "ca_key_secret_name" {
 }
 
 variable "consolidated_services_enabled" {
-  default     = false
+  default     = true
   type        = bool
   description = "(Required) True if TFE uses consolidated services."
 }

--- a/tests/public-active-active/variables.tf
+++ b/tests/public-active-active/variables.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 variable "consolidated_services_enabled" {
-  default     = false
+  default     = true
   type        = bool
   description = "(Required) True if TFE uses consolidated services."
 }

--- a/tests/standalone-external/variables.tf
+++ b/tests/standalone-external/variables.tf
@@ -8,7 +8,7 @@ variable "bypass_preflight_checks" {
 }
 
 variable "consolidated_services_enabled" {
-  default     = false
+  default     = true
   type        = bool
   description = "(Required) True if TFE uses consolidated services."
 }

--- a/tests/standalone-mounted-disk/variables.tf
+++ b/tests/standalone-mounted-disk/variables.tf
@@ -9,7 +9,7 @@ variable "bypass_preflight_checks" {
 }
 
 variable "consolidated_services_enabled" {
-  default     = false
+  default     = true
   type        = bool
   description = "(Required) True if TFE uses consolidated services."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -800,7 +800,7 @@ variable "capacity_memory" {
 }
 
 variable "consolidated_services_enabled" {
-  default     = false
+  default     = true
   type        = bool
   description = "(Required if var.is_replicated_deployment is true) True if TFE uses consolidated services."
 }


### PR DESCRIPTION
## Background
#226 
This is a followup PR so that the `consolidated_services_enabled` variable is defaulted to `true`. 