### PR TITLE
defaults auth to false

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -495,7 +495,7 @@ variable "redis_size" {
 }
 
 variable "redis_use_password_auth" {
-  default     = true
+  default     = false
   type        = bool
   description = "If set to false, the Redis instance will be accessible without authentication. enable_authentication can only be set to false if a subnet_id is specified; and only works if there aren't existing instances within the subnet with enable_authentication set to true."
 }


### PR DESCRIPTION
## Background

Need to ensure that if we're not using AUTH, it's defaulted to false.
```
 "TFE_REDIS_USE_AUTH": "false"
"TFE_REDIS_USE_TLS": "false"
```
