### PR TITLE
default license secret name to null

### DIFF
--- a/tests/private-active-active/data.tf
+++ b/tests/private-active-active/data.tf
@@ -17,6 +17,8 @@ data "azurerm_key_vault_secret" "vm_key" {
 }
 
 data "azurerm_key_vault_secret" "tfe_license" {
+  count = var.tfe_license_secret_name == null ? 0 : 1
+
   name         = var.tfe_license_secret_name
   key_vault_id = var.key_vault_id
 }

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -52,7 +52,7 @@ module "private_active_active" {
   # Bootstrapping resources
   bypass_preflight_checks     = true
   load_balancer_certificate   = data.azurerm_key_vault_certificate.load_balancer
-  tfe_license_secret_id       = data.azurerm_key_vault_secret.tfe_license[0].id
+  tfe_license_secret_id       = var.tfe_license_secret_name == null ? var.tfe_license_secret_name : data.azurerm_key_vault_secret.tfe_license[0].id
   vm_certificate_secret       = data.azurerm_key_vault_secret.vm_certificate
   vm_key_secret               = data.azurerm_key_vault_secret.vm_key
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -52,7 +52,7 @@ module "private_active_active" {
   # Bootstrapping resources
   bypass_preflight_checks     = true
   load_balancer_certificate   = data.azurerm_key_vault_certificate.load_balancer
-  tfe_license_secret_id       = data.azurerm_key_vault_secret.tfe_license.id
+  tfe_license_secret_id       = data.azurerm_key_vault_secret.tfe_license[0].id
   vm_certificate_secret       = data.azurerm_key_vault_secret.vm_certificate
   vm_key_secret               = data.azurerm_key_vault_secret.vm_key
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"

--- a/tests/private-active-active/variables.tf
+++ b/tests/private-active-active/variables.tf
@@ -79,6 +79,7 @@ variable "tfe_image_tag" {
 }
 
 variable "tfe_license_secret_name" {
+  default     = null
   type        = string
   description = "Name of the secret under which the Base64 encoded TFE license is stored in the Azure Key Vault"
 }

--- a/tests/private-tcp-active-active/data.tf
+++ b/tests/private-tcp-active-active/data.tf
@@ -22,6 +22,8 @@ data "azurerm_key_vault_secret" "ca_key" {
 }
 
 data "azurerm_key_vault_secret" "tfe_license" {
+  count = var.tfe_license_secret_name == null ? 0 : 1
+
   name         = var.tfe_license_secret_name
   key_vault_id = var.key_vault_id
 }

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -53,7 +53,7 @@ module "private_tcp_active_active" {
 
   # Bootstrapping resources
   bypass_preflight_checks     = true
-  tfe_license_secret_id       = data.azurerm_key_vault_secret.tfe_license[0].id
+  tfe_license_secret_id       = var.tfe_license_secret_name == null ? var.tfe_license_secret_name : data.azurerm_key_vault_secret.tfe_license[0].id
   vm_certificate_secret       = data.azurerm_key_vault_secret.vm_certificate
   vm_key_secret               = data.azurerm_key_vault_secret.vm_key
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -53,7 +53,7 @@ module "private_tcp_active_active" {
 
   # Bootstrapping resources
   bypass_preflight_checks     = true
-  tfe_license_secret_id       = data.azurerm_key_vault_secret.tfe_license.id
+  tfe_license_secret_id       = data.azurerm_key_vault_secret.tfe_license[0].id
   vm_certificate_secret       = data.azurerm_key_vault_secret.vm_certificate
   vm_key_secret               = data.azurerm_key_vault_secret.vm_key
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"

--- a/tests/private-tcp-active-active/variables.tf
+++ b/tests/private-tcp-active-active/variables.tf
@@ -84,6 +84,7 @@ variable "tfe_image_tag" {
 }
 
 variable "tfe_license_secret_name" {
+  default     = null
   type        = string
   description = "Name of the secret under which the Base64 encoded TFE license is stored in the Azure Key Vault"
 }

--- a/tests/public-active-active/data.tf
+++ b/tests/public-active-active/data.tf
@@ -17,6 +17,8 @@ data "azurerm_key_vault_secret" "vm_key" {
 }
 
 data "azurerm_key_vault_secret" "tfe_license" {
+  count = var.tfe_license_secret_name == null ? 0 : 1
+
   name         = var.tfe_license_secret_name
   key_vault_id = var.key_vault_id
 }

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -18,7 +18,7 @@ module "public_active_active" {
 
   # Bootstrapping resources
   load_balancer_certificate   = data.azurerm_key_vault_certificate.load_balancer
-  tfe_license_secret_id       = data.azurerm_key_vault_secret.tfe_license.id
+  tfe_license_secret_id       = data.azurerm_key_vault_secret.tfe_license[0].id
   vm_certificate_secret       = data.azurerm_key_vault_secret.vm_certificate
   vm_key_secret               = data.azurerm_key_vault_secret.vm_key
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -18,7 +18,7 @@ module "public_active_active" {
 
   # Bootstrapping resources
   load_balancer_certificate   = data.azurerm_key_vault_certificate.load_balancer
-  tfe_license_secret_id       = data.azurerm_key_vault_secret.tfe_license[0].id
+  tfe_license_secret_id       = var.tfe_license_secret_name == null ? var.tfe_license_secret_name : data.azurerm_key_vault_secret.tfe_license[0].id
   vm_certificate_secret       = data.azurerm_key_vault_secret.vm_certificate
   vm_key_secret               = data.azurerm_key_vault_secret.vm_key
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"

--- a/tests/public-active-active/variables.tf
+++ b/tests/public-active-active/variables.tf
@@ -69,6 +69,7 @@ variable "tfe_image_tag" {
 }
 
 variable "tfe_license_secret_name" {
+  default     = null
   type        = string
   description = "Name of the secret under which the Base64 encoded TFE license is stored in the Azure Key Vault"
 }

--- a/tests/standalone-external/main.tf
+++ b/tests/standalone-external/main.tf
@@ -53,9 +53,6 @@ module "standalone_external" {
   create_bastion = false
   tags           = local.common_tags
 
-  release_sequence         = 733
-  metrics_endpoint_enabled = true
-
   # FDO Specific Values
   is_replicated_deployment  = var.is_replicated_deployment
   hc_license                = var.hc_license

--- a/tests/standalone-external/main.tf
+++ b/tests/standalone-external/main.tf
@@ -53,6 +53,9 @@ module "standalone_external" {
   create_bastion = false
   tags           = local.common_tags
 
+  release_sequence         = 733
+  metrics_endpoint_enabled = true
+
   # FDO Specific Values
   is_replicated_deployment  = var.is_replicated_deployment
   hc_license                = var.hc_license


### PR DESCRIPTION
## Background

When running tests for #227 I noticed that the tests broke after 1) changing from using `legacy` to `replicated` in non-FDO deployments, and 2) that when we changed the default to be FDO tests, we needed account for the Replicated license secret not being there if it's an FDO deployment.

## How Has This Been Tested

Below.

The following pass:
- [x] private-active-active
- [x] private-tcp-active-active
- [x] public-active-active
- [x] standalone-external
- [x] standalone-mounted-disk
- [x] private-active-active-replicated
- [x] private-tcp-active-active-replicated
- [x] public-active-active-replicated
- [x] standalone-external-replicated
- [x] standalone-mounted-disk-replicated