### PR TITLE
use exact regex expressions for test names

### DIFF
--- a/.github/workflows/handler-destroy.yml
+++ b/.github/workflows/handler-destroy.yml
@@ -10,7 +10,7 @@ jobs:
     uses: hashicorp/terraform-random-tfe-utility/.github/workflows/destroy.yml@main
     secrets: inherit
     name: Destroy resources from Azure Public Active/Active
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'public-active-active') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'public-active-active' }}
     with:
       cloud: Azure
       test_name: Public Active/Active
@@ -27,7 +27,7 @@ jobs:
     uses: hashicorp/terraform-random-tfe-utility/.github/workflows/destroy.yml@main
     secrets: inherit
     name: Destroy resources from Azure Private Active/Active
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-active-active') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'private-active-active' }}
     with:
       cloud: Azure
       test_name: Private Active/Active
@@ -44,7 +44,7 @@ jobs:
     uses: hashicorp/terraform-random-tfe-utility/.github/workflows/destroy.yml@main
     secrets: inherit
     name: Destroy resources from Azure Private TCP Active/Active
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-tcp-active-active') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'private-tcp-active-active' }}
     with:
       cloud: Azure
       test_name: Private TCP Active/Active
@@ -61,7 +61,7 @@ jobs:
     uses: hashicorp/terraform-random-tfe-utility/.github/workflows/destroy.yml@main
     secrets: inherit
     name: Destroy resources from Azure Standalone External
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'standalone-external') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'standalone-external' }}
     with:
       cloud: Azure
       test_name: Standalone External
@@ -85,7 +85,7 @@ jobs:
     uses: hashicorp/terraform-random-tfe-utility/.github/workflows/destroy.yml@main
     secrets: inherit
     name: Destroy resources from Azure Standalone Mounted Disk
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'standalone-mounted-disk') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'standalone-mounted-disk' }}
     with:
       cloud: Azure
       test_name: Standalone Mounted Disk
@@ -109,7 +109,7 @@ jobs:
     uses: hashicorp/terraform-random-tfe-utility/.github/workflows/destroy.yml@main
     secrets: inherit
     name: Destroy resources from Azure Public Active/Active (Replicated)
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'public-active-active-replicated') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'public-active-active-replicated' }}
     with:
       cloud: Azure
       test_name: Public Active/Active (Replicated)
@@ -127,7 +127,7 @@ jobs:
     uses: hashicorp/terraform-random-tfe-utility/.github/workflows/destroy.yml@main
     secrets: inherit
     name: Destroy resources from Azure Private Active/Active (Replicated)
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-active-active-replicated') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'private-active-active-replicated' }}
     with:
       cloud: Azure
       test_name: Private Active/Active (Replicated)
@@ -145,7 +145,7 @@ jobs:
     uses: hashicorp/terraform-random-tfe-utility/.github/workflows/destroy.yml@main
     secrets: inherit
     name: Destroy resources from Azure Private TCP Active/Active (Replicated)
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-tcp-active-active-replicated') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'private-tcp-active-active-replicated' }}
     with:
       cloud: Azure
       test_name: Private TCP Active/Active (Replicated)
@@ -163,7 +163,7 @@ jobs:
     uses: hashicorp/terraform-random-tfe-utility/.github/workflows/destroy.yml@main
     secrets: inherit
     name: Destroy resources from Azure Standalone External (Replicated)
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'standalone-external-replicated') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'standalone-external-replicated' }}
     with:
       cloud: Azure
       test_name: Standalone External (Replicated)
@@ -187,7 +187,7 @@ jobs:
     uses: hashicorp/terraform-random-tfe-utility/.github/workflows/destroy.yml@main
     secrets: inherit
     name: Destroy resources from Azure Standalone Mounted Disk (Replicated)
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'standalone-mounted-disk-replicated') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'standalone-mounted-disk-replicated' }}
     with:
       cloud: Azure
       test_name: Standalone Mounted Disk (Replicated)

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -10,7 +10,7 @@ jobs:
     uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-tests.yml@main
     secrets: inherit
     name: Run tf-test on Azure Standalone External
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'standalone-external') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'standalone-external' }}
     with:
       test_name: Standalone External (FDO)
       is_replicated_deployment: false
@@ -34,7 +34,7 @@ jobs:
     uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-tests.yml@main
     secrets: inherit
     name: Run tf-test on Azure Standalone Mounted Disk
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'standalone-mounted-disk') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'standalone-mounted-disk' }}
     with:
       test_name: Standalone Mounted Disk (FDO)
       is_replicated_deployment: false
@@ -58,7 +58,7 @@ jobs:
     uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-tests.yml@main
     secrets: inherit
     name: Run tf-test on Azure Public Active/Active
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'public-active-active') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'public-active-active' }}
     with:
       test_name: Public Active/Active (FDO)
       is_replicated_deployment: false
@@ -75,7 +75,7 @@ jobs:
     uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-tests.yml@main
     secrets: inherit
     name: Run tf-test on Azure Private Active/Active
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-active-active') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'private-active-active' }}
     with:
       test_name: Private Active/Active (FDO)
       is_replicated_deployment: false
@@ -93,7 +93,7 @@ jobs:
     uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-tests.yml@main
     secrets: inherit
     name: Run tf-test on Azure Private TCP Active/Active
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-tcp-active-active') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'private-tcp-active-active' }}
     with:
       test_name: Private TCP Active/Active (FDO)
       is_replicated_deployment: false
@@ -111,7 +111,7 @@ jobs:
     uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-tests.yml@main
     secrets: inherit
     name: Run tf-test on Azure Standalone External (Replicated)
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'standalone-external-replicated') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'standalone-external-replicated' }}
     with:
       test_name: Standalone External
       is_replicated_deployment: true
@@ -135,7 +135,7 @@ jobs:
     uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-tests.yml@main
     secrets: inherit
     name: Run tf-test on Azure Standalone Mounted Disk (Replicated)
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'standalone-mounted-disk-replicated') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'standalone-mounted-disk-replicated' }}
     with:
       test_name: Standalone Mounted Disk
       is_replicated_deployment: true
@@ -159,7 +159,7 @@ jobs:
     uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-tests.yml@main
     secrets: inherit
     name: Run tf-test on Azure Public Active/Active (Replicated)
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'public-active-active-replicated') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'public-active-active-replicated' }}
     with:
       test_name: Public Active/Active
       is_replicated_deployment: true
@@ -177,7 +177,7 @@ jobs:
     uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-tests.yml@main
     secrets: inherit
     name: Run tf-test on Azure Private Active/Active (Replicated)
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-active-active-replicated') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'private-active-active-replicated' }}
     with:
       test_name: Private Active/Active
       is_replicated_deployment: true
@@ -196,7 +196,7 @@ jobs:
     uses: hashicorp/terraform-random-tfe-utility/.github/workflows/azure-tests.yml@main
     secrets: inherit
     name: Run tf-test on Azure Private TCP Active/Active (Replicated)
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-tcp-active-active-replicated') }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.all == 'all' || github.event.client_payload.slash_command.args.unnamed.all == 'private-tcp-active-active-replicated' }}
     with:
       test_name: Private TCP Active/Active
       is_replicated_deployment: true


### PR DESCRIPTION
## Background

[TF-8610](https://hashicorp.atlassian.net/browse/TF-8610)
Right now the tests use the `contain` function for the test names, which causes more tests to run than you desire. This will force the use to use the exact name but only the test they want to run will run. The downside is that you can't put notes in that comment because it will cause it to not match exactly, but the user can simply add a follow up comment instead.

## How Has This Been Tested

Will be tested post-merge.

[TF-8610]: https://hashicorp.atlassian.net/browse/TF-8610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ