### PR TITLE
fix active-active value

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -144,7 +144,7 @@ module "tfe_init_fdo" {
   distribution      = var.distribution
   disk_path         = var.disk_path
   disk_device_name  = var.production_type == "disk" ? "disk/azure/scsi1/lun${var.vm_data_disk_lun}" : null
-  operational_mode  = var.production_type
+  operational_mode  = local.active_active ? "active-active" : var.production_type
   custom_image_tag  = var.custom_image_tag
   enable_monitoring = var.enable_monitoring
 

--- a/variables.tf
+++ b/variables.tf
@@ -544,6 +544,18 @@ variable "redis_minimum_tls_version" {
 
 # VM
 # --
+variable "http_port" {
+  default     = 80
+  type        = number
+  description = "(Optional if is_replicated_deployment is false) Port application listens on for HTTP. Default is 80."
+}
+
+variable "https_port" {
+  default     = 443
+  type        = number
+  description = "(Optional if is_replicated_deployment is false) Port application listens on for HTTPS. Default is 443."
+}
+
 variable "vm_node_count" {
   default     = 2
   type        = number
@@ -998,18 +1010,6 @@ variable "vm_key_secret" {
 
 # Proxy
 # -----
-variable "http_port" {
-  default     = 80
-  type        = number
-  description = "(Optional if is_replicated_deployment is false) Port application listens on for HTTP. Default is 80."
-}
-
-variable "https_port" {
-  default     = 443
-  type        = number
-  description = "(Optional if is_replicated_deployment is false) Port application listens on for HTTPS. Default is 443."
-}
-
 variable "no_proxy" {
   type        = list(string)
   description = "(Optional) List of IP addresses to not proxy"


### PR DESCRIPTION
## Background

[Jira TF-8610](https://hashicorp.atlassian.net/browse/TF-8610)

Just noticed this error that I wanted to fix real quick. It ensures that the operational mode is Active/Active and not external if there are two or more nodes.

## How Has This Been Tested

Below there are 10 passing tests, however, some of the destroys failed due to cloud provider issues so it looks messy. Here are the direct links to the passing tests:

## FDO
- [x] [private-active-active](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/actions/runs/6815450228/job/18534573378)
- [x] [private-tcp-active-active](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/actions/runs/6805273446/job/18504451122)
- [x] [public-active-active](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/actions/runs/6815452107/job/18534579494)
- [x] [standalone-external](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/actions/runs/6805273446/job/18504450687#step:15:2037)
- [x] [standalone-mounted-disk](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/actions/runs/6805273446/job/18504451575)

## Replicated
- [x] [private-active-active-replicated](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/actions/runs/6805273446/job/18504451749)
- [x] [private-tcp-active-active-replicated](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/actions/runs/6815450920/job/18534575391)
- [x] [public-active-active-replicated](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/actions/runs/6805273446/job/18504452241)
- [x] [standalone-external-replicated](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/actions/runs/6805273446/job/18504451407#step:15:2054)
- [x] [standalone-mounted-disk-replicated](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/actions/runs/6805273446/job/18504452097)