### PR TITLE
add disk path to docker compose

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -137,7 +137,7 @@ module "database" {
 # Azure user data / cloud init used to install and configure TFE on instance(s) using Flexible Deployment Options
 # ---------------------------------------------------------------------------------------------------------------
 module "tfe_init_fdo" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=ah/disk_path"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=main"
   count  = var.is_replicated_deployment ? 0 : 1
 
   cloud             = "azurerm"
@@ -173,7 +173,7 @@ module "tfe_init_fdo" {
 # Docker Compose File Config for TFE on instance(s) using Flexible Deployment Options
 # ------------------------------------------------------------------------------------
 module "docker_compose_config" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/docker_compose_config?ref=ah/disk_path"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/docker_compose_config?ref=main"
   count  = var.is_replicated_deployment ? 0 : 1
 
   license_reporting_opt_out = var.license_reporting_opt_out

--- a/main.tf
+++ b/main.tf
@@ -181,6 +181,7 @@ module "docker_compose_config" {
   capacity_concurrency      = var.capacity_concurrency
   capacity_cpu              = var.capacity_cpu
   capacity_memory           = var.capacity_memory
+  disk_path                 = local.disk_mode ? var.disk_path : null
   iact_subnets              = join(",", var.iact_subnet_list)
   iact_time_limit           = var.iact_subnet_time_limit
   operational_mode          = local.active_active ? "active-active" : var.production_type

--- a/main.tf
+++ b/main.tf
@@ -137,7 +137,7 @@ module "database" {
 # Azure user data / cloud init used to install and configure TFE on instance(s) using Flexible Deployment Options
 # ---------------------------------------------------------------------------------------------------------------
 module "tfe_init_fdo" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=main"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=ah/disk_path"
   count  = var.is_replicated_deployment ? 0 : 1
 
   cloud             = "azurerm"
@@ -173,7 +173,7 @@ module "tfe_init_fdo" {
 # Docker Compose File Config for TFE on instance(s) using Flexible Deployment Options
 # ------------------------------------------------------------------------------------
 module "docker_compose_config" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/docker_compose_config?ref=main"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/docker_compose_config?ref=ah/disk_path"
   count  = var.is_replicated_deployment ? 0 : 1
 
   license_reporting_opt_out = var.license_reporting_opt_out


### PR DESCRIPTION
## Background

Relates: https://github.com/hashicorp/terraform-random-tfe-utility/pull/135

While testing a backup, @miguelhrocha discovered that the disk_path was not set for FDO deployments. It had gone unnoticed since we had not done a backup test yet using these modules as it was using the default docker mount.

## How Has This Been Tested

Passing test below. Also, here you can see that the postgres data is on the instance.

<img width="1437" alt="Screenshot 2023-11-15 at 10 28 34 AM" src="https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/assets/18335499/409735b5-2982-43fe-a0d0-e93ecc644de7">
