### PR TITLE
add registry variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -137,7 +137,7 @@ module "database" {
 # Azure user data / cloud init used to install and configure TFE on instance(s) using Flexible Deployment Options
 # ---------------------------------------------------------------------------------------------------------------
 module "tfe_init_fdo" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=ah/TF-10844-registry"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=main"
   count  = var.is_replicated_deployment ? 0 : 1
 
   cloud             = "azurerm"

--- a/main.tf
+++ b/main.tf
@@ -137,7 +137,7 @@ module "database" {
 # Azure user data / cloud init used to install and configure TFE on instance(s) using Flexible Deployment Options
 # ---------------------------------------------------------------------------------------------------------------
 module "tfe_init_fdo" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=main"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=ah/TF-10844-registry"
   count  = var.is_replicated_deployment ? 0 : 1
 
   cloud             = "azurerm"
@@ -164,8 +164,10 @@ module "tfe_init_fdo" {
     var.network_cidr
   ]
 
-  registry_username   = var.registry_username
-  registry_password   = var.registry_password
+  registry          = var.registry
+  registry_password = var.registry == "images.releases.hashicorp.com" ? var.hc_license : var.registry_password
+  registry_username = var.registry_username
+
   docker_compose_yaml = module.docker_compose_config[0].docker_compose_yaml
 }
 

--- a/tests/private-active-active/locals.tf
+++ b/tests/private-active-active/locals.tf
@@ -3,17 +3,17 @@
 
 locals {
   common_tags = {
-    Terraform   = "cloud"
     Environment = "${local.friendly_name_prefix}-test-private-active-active"
     Description = "Private Active/Active"
     Repository  = "hashicorp/terraform-azurerm-terraform-enterprise"
-    Team        = "Terraform Enterprise on Prem"
+    Team        = "Terraform Enterprise"
     OkToDelete  = "True"
   }
 
   friendly_name_prefix      = random_string.friendly_name.id
-  resource_group_name       = module.private_active_active.resource_group_name
+  network_proxy_subnet_cidr = "10.0.80.0/20"
   proxy_user                = "proxyuser"
   proxy_port                = "3128"
-  network_proxy_subnet_cidr = "10.0.80.0/20"
+  registry                  = "quay.io"
+  resource_group_name       = module.private_active_active.resource_group_name
 }

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -86,7 +86,8 @@ module "private_active_active" {
   http_port                 = 8080
   https_port                = 8443
   license_reporting_opt_out = true
+  registry                  = local.registry
   registry_password         = var.registry_password
   registry_username         = var.registry_username
-  tfe_image                 = "quay.io/hashicorp/terraform-enterprise:${var.tfe_image_tag}"
+  tfe_image                 = "${local.registry}/hashicorp/terraform-enterprise:${var.tfe_image_tag}"
 }

--- a/tests/private-active-active/variables.tf
+++ b/tests/private-active-active/variables.tf
@@ -55,16 +55,16 @@ variable "proxy_public_ssh_key_secret_name" {
   description = "The name of the public SSH key secret for the proxy."
 }
 
-variable "registry_username" {
-  default     = null
-  type        = string
-  description = "(Not needed if is_replicated_deployment is true) The username for the docker registry from which to source the terraform_enterprise container images."
-}
-
 variable "registry_password" {
   default     = null
   type        = string
   description = "(Not needed if is_replicated_deployment is true) The password for the docker registry from which to source the terraform_enterprise container images."
+}
+
+variable "registry_username" {
+  default     = null
+  type        = string
+  description = "(Not needed if is_replicated_deployment is true) The username for the docker registry from which to source the terraform_enterprise container images."
 }
 
 variable "resource_group_name_dns" {

--- a/tests/private-tcp-active-active/locals.tf
+++ b/tests/private-tcp-active-active/locals.tf
@@ -3,17 +3,17 @@
 
 locals {
   common_tags = {
-    Terraform   = "cloud"
     Environment = "${local.friendly_name_prefix}-test-private-tcp-active-active"
     Description = "Private TCP Active/Active"
     Repository  = "hashicorp/terraform-azurerm-terraform-enterprise"
-    Team        = "Terraform Enterprise on Prem"
+    Team        = "Terraform Enterprise"
     OkToDelete  = "True"
   }
 
   friendly_name_prefix      = random_string.friendly_name.id
-  resource_group_name       = module.private_tcp_active_active.resource_group_name
+  network_proxy_subnet_cidr = "10.0.80.0/20"
   proxy_user                = "proxyuser"
   proxy_port                = "3128"
-  network_proxy_subnet_cidr = "10.0.80.0/20"
+  registry                  = "quay.io"
+  resource_group_name       = module.private_tcp_active_active.resource_group_name
 }

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -87,7 +87,8 @@ module "private_tcp_active_active" {
   http_port                 = 8080
   https_port                = 8443
   license_reporting_opt_out = true
+  registry                  = local.registry
   registry_password         = var.registry_password
   registry_username         = var.registry_username
-  tfe_image                 = "quay.io/hashicorp/terraform-enterprise:${var.tfe_image_tag}"
+  tfe_image                 = "${local.registry}/hashicorp/terraform-enterprise:${var.tfe_image_tag}"
 }

--- a/tests/private-tcp-active-active/variables.tf
+++ b/tests/private-tcp-active-active/variables.tf
@@ -60,16 +60,16 @@ variable "proxy_public_ssh_key_secret_name" {
   description = "The name of the public SSH key secret for the proxy."
 }
 
-variable "registry_username" {
-  default     = null
-  type        = string
-  description = "(Not needed if is_replicated_deployment is true) The username for the docker registry from which to source the terraform_enterprise container images."
-}
-
 variable "registry_password" {
   default     = null
   type        = string
   description = "(Not needed if is_replicated_deployment is true) The password for the docker registry from which to source the terraform_enterprise container images."
+}
+
+variable "registry_username" {
+  default     = null
+  type        = string
+  description = "(Not needed if is_replicated_deployment is true) The username for the docker registry from which to source the terraform_enterprise container images."
 }
 
 variable "resource_group_name_dns" {

--- a/tests/public-active-active/locals.tf
+++ b/tests/public-active-active/locals.tf
@@ -3,13 +3,13 @@
 
 locals {
   common_tags = {
-    Terraform   = "cloud"
     Environment = "${local.friendly_name_prefix}-test-public-active-active"
     Description = "Public Active/Active"
     Repository  = "hashicorp/terraform-azurerm-terraform-enterprise"
-    Team        = "Terraform Enterprise on Prem"
+    Team        = "Terraform Enterprise"
     OkToDelete  = "True"
   }
 
   friendly_name_prefix = random_string.friendly_name.id
+  registry             = "quay.io"
 }

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -45,8 +45,9 @@ module "public_active_active" {
   http_port                 = 8080
   https_port                = 8443
   license_reporting_opt_out = true
+  registry                  = local.registry
   registry_password         = var.registry_password
   registry_username         = var.registry_username
-  tfe_image                 = "quay.io/hashicorp/terraform-enterprise:${var.tfe_image_tag}"
+  tfe_image                 = "${local.registry}/hashicorp/terraform-enterprise:${var.tfe_image_tag}"
 }
 

--- a/tests/public-active-active/variables.tf
+++ b/tests/public-active-active/variables.tf
@@ -45,16 +45,16 @@ variable "key_vault_id" {
   description = "The identity of the Key Vault which contains secrets and certificates."
 }
 
-variable "registry_username" {
-  default     = null
-  type        = string
-  description = "(Not needed if is_replicated_deployment is true) The username for the docker registry from which to source the terraform_enterprise container images."
-}
-
 variable "registry_password" {
   default     = null
   type        = string
   description = "(Not needed if is_replicated_deployment is true) The password for the docker registry from which to source the terraform_enterprise container images."
+}
+
+variable "registry_username" {
+  default     = null
+  type        = string
+  description = "(Not needed if is_replicated_deployment is true) The username for the docker registry from which to source the terraform_enterprise container images."
 }
 
 variable "resource_group_name_dns" {

--- a/tests/standalone-external/locals.tf
+++ b/tests/standalone-external/locals.tf
@@ -3,14 +3,14 @@
 
 locals {
   common_tags = {
-    Terraform   = "False"
     Environment = "${local.friendly_name_prefix}-test-standalone-external"
-    Description = "Standalone, External Services scenario deployed from CircleCI"
+    Description = "Standalone, External Services scenario"
     Repository  = "hashicorp/terraform-azurerm-terraform-enterprise"
-    Team        = "Terraform Enterprise on Prem"
+    Team        = "Terraform Enterprise"
     OkToDelete  = "True"
   }
 
-  utility_module_test  = var.license_file == null
   friendly_name_prefix = random_string.friendly_name.id
+  registry             = "quay.io"
+  utility_module_test  = var.license_file == null
 }

--- a/tests/standalone-external/main.tf
+++ b/tests/standalone-external/main.tf
@@ -59,7 +59,8 @@ module "standalone_external" {
   http_port                 = 8080
   https_port                = 8443
   license_reporting_opt_out = true
+  registry                  = local.registry
   registry_password         = var.registry_password
   registry_username         = var.registry_username
-  tfe_image                 = "quay.io/hashicorp/terraform-enterprise:${var.tfe_image_tag}"
+  tfe_image                 = "${local.registry}/hashicorp/terraform-enterprise:${var.tfe_image_tag}"
 }

--- a/tests/standalone-external/outputs.tf
+++ b/tests/standalone-external/outputs.tf
@@ -7,7 +7,7 @@ output "replicated_console_password" {
 }
 
 output "replicated_console_url" {
-  value       = "${module.standalone_external.tfe_application_url}:8800"
+  value       = module.standalone_mounted_disk.tfe_console_url
   description = "Terraform Enterprise Console URL"
 }
 

--- a/tests/standalone-external/outputs.tf
+++ b/tests/standalone-external/outputs.tf
@@ -7,7 +7,7 @@ output "replicated_console_password" {
 }
 
 output "replicated_console_url" {
-  value       = module.standalone_mounted_disk.tfe_console_url
+  value       = module.standalone_external.tfe_console_url
   description = "Terraform Enterprise Console URL"
 }
 

--- a/tests/standalone-external/variables.tf
+++ b/tests/standalone-external/variables.tf
@@ -48,16 +48,16 @@ variable "license_file" {
   description = "The local path to the Terraform Enterprise license to be provided by CI."
 }
 
-variable "registry_username" {
-  default     = null
-  type        = string
-  description = "(Not needed if is_replicated_deployment is true) The username for the docker registry from which to source the terraform_enterprise container images."
-}
-
 variable "registry_password" {
   default     = null
   type        = string
   description = "(Not needed if is_replicated_deployment is true) The password for the docker registry from which to source the terraform_enterprise container images."
+}
+
+variable "registry_username" {
+  default     = null
+  type        = string
+  description = "(Not needed if is_replicated_deployment is true) The username for the docker registry from which to source the terraform_enterprise container images."
 }
 
 variable "resource_group_name_dns" {

--- a/tests/standalone-mounted-disk/locals.tf
+++ b/tests/standalone-mounted-disk/locals.tf
@@ -3,9 +3,8 @@
 
 locals {
   common_tags = {
-    Terraform   = "False"
     Environment = "${local.friendly_name_prefix}-test-standalone-mounted-disk"
-    Description = "Standalone, Mounted Disk scenario deployed from CircleCI"
+    Description = "Standalone, Mounted Disk scenario"
     Repository  = "hashicorp/terraform-azurerm-terraform-enterprise"
     Team        = "Terraform Enterprise on Prem"
     OkToDelete  = "True"
@@ -40,6 +39,9 @@ locals {
     var.vm_image_sku != null &&
     var.vm_image_version != null
   ) ? var.vm_image_version : null
+
   utility_module_test  = var.license_file == null
   friendly_name_prefix = random_string.friendly_name.id
+  # registry             = "quay.io"
+  registry = "images.releases.hashicorp.com"
 }

--- a/tests/standalone-mounted-disk/locals.tf
+++ b/tests/standalone-mounted-disk/locals.tf
@@ -6,7 +6,7 @@ locals {
     Environment = "${local.friendly_name_prefix}-test-standalone-mounted-disk"
     Description = "Standalone, Mounted Disk scenario"
     Repository  = "hashicorp/terraform-azurerm-terraform-enterprise"
-    Team        = "Terraform Enterprise on Prem"
+    Team        = "Terraform Enterprise"
     OkToDelete  = "True"
   }
   vm_image_id = (
@@ -40,8 +40,7 @@ locals {
     var.vm_image_version != null
   ) ? var.vm_image_version : null
 
-  utility_module_test  = var.license_file == null
   friendly_name_prefix = random_string.friendly_name.id
-  # registry             = "quay.io"
-  registry = "images.releases.hashicorp.com"
+  registry             = "quay.io"
+  utility_module_test  = var.license_file == null
 }

--- a/tests/standalone-mounted-disk/main.tf
+++ b/tests/standalone-mounted-disk/main.tf
@@ -69,7 +69,8 @@ module "standalone_mounted_disk" {
   http_port                 = 8080
   https_port                = 8443
   license_reporting_opt_out = true
+  registry                  = local.registry
   registry_password         = var.registry_password
   registry_username         = var.registry_username
-  tfe_image                 = "quay.io/hashicorp/terraform-enterprise:${var.tfe_image_tag}"
+  tfe_image                 = "${local.registry}/hashicorp/terraform-enterprise:${var.tfe_image_tag}"
 }

--- a/tests/standalone-mounted-disk/outputs.tf
+++ b/tests/standalone-mounted-disk/outputs.tf
@@ -7,7 +7,7 @@ output "replicated_console_password" {
 }
 
 output "replicated_console_url" {
-  value       = module.standalone_mounted_disk.replicated_console_url
+  value       = module.standalone_mounted_disk.tfe_console_url
   description = "Terraform Enterprise Console URL"
 }
 

--- a/tests/standalone-mounted-disk/outputs.tf
+++ b/tests/standalone-mounted-disk/outputs.tf
@@ -7,7 +7,7 @@ output "replicated_console_password" {
 }
 
 output "replicated_console_url" {
-  value       = "${module.standalone_mounted_disk.tfe_application_url}:8800"
+  value       = module.standalone_mounted_disk.replicated_console_url
   description = "Terraform Enterprise Console URL"
 }
 

--- a/tests/standalone-mounted-disk/variables.tf
+++ b/tests/standalone-mounted-disk/variables.tf
@@ -53,16 +53,16 @@ variable "license_file" {
   description = "The local path to the Terraform Enterprise license to be provided by CI."
 }
 
-variable "registry_username" {
-  default     = null
-  type        = string
-  description = "(Not needed if is_replicated_deployment is true) The username for the docker registry from which to source the terraform_enterprise container images."
-}
-
 variable "registry_password" {
   default     = null
   type        = string
   description = "(Not needed if is_replicated_deployment is true) The password for the docker registry from which to source the terraform_enterprise container images."
+}
+
+variable "registry_username" {
+  default     = null
+  type        = string
+  description = "(Not needed if is_replicated_deployment is true) The username for the docker registry from which to source the terraform_enterprise container images."
 }
 
 variable "resource_group_name_dns" {

--- a/variables.tf
+++ b/variables.tf
@@ -36,9 +36,9 @@ variable "tfe_subdomain" {
 }
 
 variable "tfe_image" {
-  default     = "quay.io/hashicorp/terraform-enterprise:latest"
+  default     = "images.releases.hashicorp.com/hashicorp/terraform-enterprise:v202311-1"
   type        = string
-  description = "(Not needed if is_replicated_deployment is true) The registry path, image name, and image version (e.g. \"quay.io/hashicorp/terraform-enterprise:1234567\")"
+  description = "(Not needed if is_replicated_deployment is true) The registry path, image name, and image version"
 }
 
 # DNS
@@ -841,16 +841,22 @@ variable "hairpin_addressing" {
   description = "In some cloud environments, HTTP clients running on instances behind a loadbalancer cannot send requests to the public hostname of that load balancer. Use this setting to configure TFE services to redirect requests for the installation's FQDN to the instance's internal IP address. Defaults to false."
 }
 
-variable "registry_username" {
-  default     = null
+variable "registry" {
+  default     = "images.releases.hashicorp.com"
   type        = string
-  description = "(Not needed if is_replicated_deployment is true) The username for the docker registry from which to source the terraform_enterprise container images."
+  description = "(Not needed if is_replicated_deployment is true) The docker registry from which to source the terraform_enterprise container images."
 }
 
 variable "registry_password" {
   default     = null
   type        = string
-  description = "(Not needed if is_replicated_deployment is true) The password for the docker registry from which to source the terraform_enterprise container images."
+  description = "(Not needed if is_replicated_deployment is true or if registry is 'images.releases.hashicorp.com') The password for the docker registry from which to source the terraform_enterprise container images."
+}
+
+variable "registry_username" {
+  default     = "terraform"
+  type        = string
+  description = "(Not needed if is_replicated_deployment is true) The username for the docker registry from which to source the terraform_enterprise container images."
 }
 
 variable "run_pipeline_image" {


### PR DESCRIPTION
## Background

[Jira TF-10844](https://hashicorp.atlassian.net/browse/TF-10844)

This branch updates the module to use the docker login changes introduced in https://github.com/hashicorp/terraform-random-tfe-utility/pull/137. 

All module tests are updated to accommodate this change.

(I also took the liberty to alphabetize and a couple of small clean up tasks while I was in there.)

### TODO:
- [x] Change the module ref back to `main`

## How Has This Been Tested

FDO tests have been run in comments below. (The one failed destroy was just an Azure bug.)

Also, I successfully ran this locally with the `local.registry` value being `images.releases.hashicorp.com`.