### PR TITLE
TF-10708: adds outputs for release testing

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -292,7 +292,7 @@ module "settings" {
 # Azure user data / cloud init used to install and configure TFE on instance(s)
 # -----------------------------------------------------------------------------
 module "tfe_init_replicated" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init_replicated?ref=main"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init_replicated?ref=TF-10708"
   count  = var.is_replicated_deployment ? 1 : 0
 
   # TFE & Replicated Configuration data

--- a/main.tf
+++ b/main.tf
@@ -292,7 +292,7 @@ module "settings" {
 # Azure user data / cloud init used to install and configure TFE on instance(s)
 # -----------------------------------------------------------------------------
 module "tfe_init_replicated" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init_replicated?ref=TF-10708"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init_replicated?ref=main"
   count  = var.is_replicated_deployment ? 1 : 0
 
   # TFE & Replicated Configuration data

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -142,3 +142,8 @@ resource "azurerm_virtual_machine_scale_set_extension" "main" {
     "requestPath" : "/_health_check"
   })
 }
+
+data "azurerm_virtual_machine_scale_set" "example" {
+  name                = azurerm_linux_virtual_machine_scale_set.tfe_vmss.name
+  resource_group_name = var.resource_group_name
+}

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -143,7 +143,7 @@ resource "azurerm_virtual_machine_scale_set_extension" "main" {
   })
 }
 
-data "azurerm_virtual_machine_scale_set" "example" {
+data "azurerm_virtual_machine_scale_set" "tfe_vmss" {
   name                = azurerm_linux_virtual_machine_scale_set.tfe_vmss.name
   resource_group_name = var.resource_group_name
 }

--- a/modules/vm/outputs.tf
+++ b/modules/vm/outputs.tf
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: MPL-2.0
 
 output "vmss_name" {
-  value = azurerm_linux_virtual_machine_scale_set.tfe_vmss.name
+  value       = azurerm_linux_virtual_machine_scale_set.tfe_vmss.name
   description = "The name of the virtual machine scale set"
 }
 
 output "vmss_instance_ids" {
-  value = toset([for i in data.azurerm_virtual_machine_scale_set.tfe_vmss.instances[*] : i.instance_id ])
+  value       = toset([for i in data.azurerm_virtual_machine_scale_set.tfe_vmss.instances[*] : i.instance_id])
   description = "A list of the virual machine scale set VMs ids"
 }

--- a/modules/vm/outputs.tf
+++ b/modules/vm/outputs.tf
@@ -3,8 +3,10 @@
 
 output "vmss_name" {
   value = azurerm_linux_virtual_machine_scale_set.tfe_vmss.name
+  description = "The name of the virtual machine scale set"
 }
 
 output "vmss_instance_ids" {
-  value = data.azurerm_virtual_machine_scale_set.example.instances
+  value = toset([for i in data.azurerm_virtual_machine_scale_set.tfe_vmss.instances[*] : i.instance_id ])
+  description = "A list of the virual machine scale set VMs ids"
 }

--- a/modules/vm/outputs.tf
+++ b/modules/vm/outputs.tf
@@ -1,3 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+output "vmss_name" {
+  value = azurerm_linux_virtual_machine_scale_set.tfe_vmss.name
+}
+
+output "vmss_instance_ids" {
+  value = data.azurerm_virtual_machine_scale_set.example.instances
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -124,3 +124,11 @@ output "instance_user_name" {
   value       = var.vm_user
   description = "The admin user on the TFE instance(s)"
 }
+
+output "vmss_name" {
+  value = module.vm.vmss_name
+}
+
+output "vmss_vm_ids" {
+  value = module.vm.vmss_instance_ids
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -126,11 +126,11 @@ output "instance_user_name" {
 }
 
 output "vmss_name" {
-  value = module.vm.vmss_name
+  value       = module.vm.vmss_name
   description = "The name of the virtual machine scale set"
 }
 
 output "vmss_instance_ids" {
-  value = module.vm.vmss_instance_ids
+  value       = module.vm.vmss_instance_ids
   description = "A list of the virual machine scale set VMs ids"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -127,8 +127,10 @@ output "instance_user_name" {
 
 output "vmss_name" {
   value = module.vm.vmss_name
+  description = "The name of the virtual machine scale set"
 }
 
-output "vmss_vm_ids" {
+output "vmss_instance_ids" {
   value = module.vm.vmss_instance_ids
+  description = "A list of the virual machine scale set VMs ids"
 }


### PR DESCRIPTION
## Background

[Jira](https://hashicorp.atlassian.net/browse/TF-10708)

Includes some outputs to be digested by the Azure Replicated a/a release test scenario ([defined here](https://github.com/hashicorp/terraform-release-testing-terraform-enterprise/pull/8)).

[Depends on this PR being merged as well.](https://github.com/hashicorp/terraform-random-tfe-utility/pull/144) 

## How Has This Been Tested

Outputs are visible to the module output: 
<img width="390" alt="image" src="https://github.com/hashicorp/terraform-azurerm-terraform-enterprise/assets/7529607/a92827c7-bc6c-45ab-8a77-e40a805e4a5e">

