### PR TITLE
Add extern_vault_token_renew to FDO config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -228,11 +228,12 @@ module "runtime_container_engine_config" {
   redis_use_tls  = local.redis.hostname == null ? null : var.redis_use_tls
   redis_use_auth = local.redis.hostname == null ? null : var.redis_use_password_auth
 
-  vault_address   = var.extern_vault_addr
-  vault_namespace = var.extern_vault_namespace
-  vault_path      = var.extern_vault_path
-  vault_role_id   = var.extern_vault_role_id
-  vault_secret_id = var.extern_vault_secret_id
+  vault_address     = var.extern_vault_addr
+  vault_namespace   = var.extern_vault_namespace
+  vault_path        = var.extern_vault_path
+  vault_role_id     = var.extern_vault_role_id
+  vault_secret_id   = var.extern_vault_secret_id
+  vault_token_renew = var.extern_vault_token_renew
 }
 
 # ------------------------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -97,6 +97,12 @@ variable "extern_vault_secret_id" {
   description = "(Required if var.extern_vault_enable = true) AppRole SecretId to use to authenticate with the Vault cluster."
 }
 
+variable "extern_vault_token_renew" {
+  default     = 3600
+  type        = number
+  description = "(Optional if var.extern_vault_enable = true) How often (in seconds) to renew the Vault token. Defaults to 3600."
+}
+
 # Provider
 # --------
 variable "location" {


### PR DESCRIPTION
## Background

Adds the `extern_vault_token_renew` to the module configuration. This value is optional when using an external vault instance configuration, and it defaults to 3600.
