### PR TITLE
Make "active-active" a valid production_type value

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -6,9 +6,8 @@
 locals {
   # TFE Architecture
   # ----------------
-  # Determine whether or not TFE in active-active mode based on node count, by default standalone is assumed
-  active_active = var.vm_node_count >= 2 ? true : false
-  disk_mode     = var.production_type == "disk" ? true : false
+  active_active = var.vm_node_count >= 2 || var.production_type == "active-active"
+  disk_mode     = var.production_type == "disk"
 
   # Network
   # -------

--- a/variables.tf
+++ b/variables.tf
@@ -916,16 +916,12 @@ variable "tls_version" {
 variable "production_type" {
   default     = null
   type        = string
-  description = "Where Terraform Enterprise application data will be stored. Valid values are `external`, `disk`, or `null`. Choose `external` when storing application data in an external object storage service and database. Choose `disk` when storing application data in a directory on the Terraform Enterprise instance itself. Leave it `null` when you want Terraform Enterprise to use its own default."
+  description = "Where Terraform Enterprise application data will be stored. Valid values are `external`, `disk`, `active-active` or `null`. Choose `external` when storing application data in an external object storage service and database. Choose `disk` when storing application data in a directory on the Terraform Enterprise instance itself. Chose `active-active` when deploying more than 1 node. Leave it `null` when you want Terraform Enterprise to use its own default."
 
   validation {
-    condition = (
-      var.production_type == "external" ||
-      var.production_type == "disk" ||
-      var.production_type == null
-    )
+    condition = contains(["external", "disk", "active-active", null], var.production_type)
 
-    error_message = "The production_type must be 'external', 'disk', or omitted."
+    error_message = "The production_type must be 'external', 'disk', `active-active` or omitted."
   }
 }
 


### PR DESCRIPTION
## Background

The `active-active` mode used to be identified by the `vm_node_count` parameter. This breaks possible workflows when someone wants to modify the node_count to a value lower than 2 for maintenance or other reasons.

This adds a non-breaking change to decouple the `active-active` mode from the `vm_node_count` parameter.