### PR TITLE
[TF-15070] Rename production_type to operational_mode, and make active-active simple

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -6,8 +6,8 @@
 locals {
   # TFE Architecture
   # ----------------
-  active_active = var.vm_node_count >= 2 || var.production_type == "active-active"
-  disk_mode     = var.production_type == "disk"
+  active_active = var.vm_node_count >= 2 || var.operational_mode == "active-active"
+  disk_mode     = var.operational_mode == "disk"
 
   # Network
   # -------

--- a/locals.tf
+++ b/locals.tf
@@ -6,7 +6,7 @@
 locals {
   # TFE Architecture
   # ----------------
-  disk_mode     = var.operational_mode == "disk"
+  disk_mode = var.operational_mode == "disk"
 
   # Network
   # -------

--- a/locals.tf
+++ b/locals.tf
@@ -6,7 +6,6 @@
 locals {
   # TFE Architecture
   # ----------------
-  active_active = var.vm_node_count >= 2 || var.operational_mode == "active-active"
   disk_mode     = var.operational_mode == "disk"
 
   # Network

--- a/main.tf
+++ b/main.tf
@@ -144,7 +144,7 @@ module "tfe_init_fdo" {
   distribution      = var.distribution
   disk_path         = var.disk_path
   disk_device_name  = var.production_type == "disk" ? "disk/azure/scsi1/lun${var.vm_data_disk_lun}" : null
-  operational_mode  = local.active_active ? "active-active" : var.production_type
+  operational_mode  = var.production_type
   custom_image_tag  = var.custom_image_tag
   enable_monitoring = var.enable_monitoring
 
@@ -258,7 +258,6 @@ module "settings" {
 
   # Replicated Base Configuration
   hostname                                  = module.load_balancer.fqdn
-  enable_active_active                      = local.active_active
   tfe_license_bootstrap_airgap_package_path = var.tfe_license_bootstrap_airgap_package_path
   tfe_license_file_location                 = var.tfe_license_file_location
   tls_bootstrap_cert_pathname               = var.tls_bootstrap_cert_pathname

--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,7 @@ module "network" {
   resource_group_name  = module.resource_groups.resource_group_name
   location             = var.location
 
-  active_active            = var.production_type == "active-active"
+  active_active            = var.operational_mode == "active-active"
   enable_ssh               = var.enable_ssh
   is_replicated_deployment = var.is_replicated_deployment
 
@@ -85,7 +85,7 @@ module "network" {
 # -----------------------------------------------------------------------------
 module "redis" {
   source = "./modules/redis"
-  count  = var.production_type == "active-active" ? 1 : 0
+  count  = var.operational_mode == "active-active" ? 1 : 0
 
   resource_group_name = module.resource_groups.resource_group_name
   location            = var.location
@@ -143,8 +143,8 @@ module "tfe_init_fdo" {
   cloud             = "azurerm"
   distribution      = var.distribution
   disk_path         = var.disk_path
-  disk_device_name  = var.production_type == "disk" ? "disk/azure/scsi1/lun${var.vm_data_disk_lun}" : null
-  operational_mode  = var.production_type
+  disk_device_name  = var.operational_mode == "disk" ? "disk/azure/scsi1/lun${var.vm_data_disk_lun}" : null
+  operational_mode  = var.operational_mode
   custom_image_tag  = var.custom_image_tag
   enable_monitoring = var.enable_monitoring
 
@@ -189,7 +189,7 @@ module "runtime_container_engine_config" {
   disk_path                   = local.disk_mode ? var.disk_path : null
   iact_subnets                = join(",", var.iact_subnet_list)
   iact_time_limit             = var.iact_subnet_time_limit
-  operational_mode            = var.production_type
+  operational_mode            = var.operational_mode
   run_pipeline_image          = var.run_pipeline_image
   tfe_image                   = var.tfe_image
   tfe_license                 = var.hc_license
@@ -250,7 +250,7 @@ module "settings" {
   hairpin_addressing     = var.hairpin_addressing
   iact_subnet_list       = var.iact_subnet_list
   pg_extra_params        = var.pg_extra_params
-  production_type        = var.production_type
+  production_type        = var.operational_mode
   release_sequence       = var.release_sequence
   trusted_proxies        = local.trusted_proxies
 
@@ -298,7 +298,7 @@ module "tfe_init_replicated" {
   cloud                    = "azurerm"
   distribution             = var.distribution
   disk_path                = var.disk_path
-  disk_device_name         = var.production_type == "disk" ? "disk/azure/scsi1/lun${var.vm_data_disk_lun}" : null
+  disk_device_name         = var.operational_mode == "disk" ? "disk/azure/scsi1/lun${var.vm_data_disk_lun}" : null
   tfe_configuration        = module.settings[0].tfe_configuration
   replicated_configuration = module.settings[0].replicated_configuration
   airgap_url               = var.airgap_url
@@ -342,7 +342,7 @@ module "load_balancer" {
   zones                = var.zones
 
   # General
-  active_active            = var.production_type == "active-active"
+  active_active            = var.operational_mode == "active-active"
   domain_name              = var.domain_name
   is_replicated_deployment = var.is_replicated_deployment
   tfe_subdomain            = var.tfe_subdomain

--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,7 @@ module "network" {
   resource_group_name  = module.resource_groups.resource_group_name
   location             = var.location
 
-  active_active            = local.active_active
+  active_active            = var.production_type == "active-active"
   enable_ssh               = var.enable_ssh
   is_replicated_deployment = var.is_replicated_deployment
 
@@ -85,7 +85,7 @@ module "network" {
 # -----------------------------------------------------------------------------
 module "redis" {
   source = "./modules/redis"
-  count  = local.active_active == true ? 1 : 0
+  count  = var.production_type == "active-active" ? 1 : 0
 
   resource_group_name = module.resource_groups.resource_group_name
   location            = var.location
@@ -189,7 +189,7 @@ module "runtime_container_engine_config" {
   disk_path                   = local.disk_mode ? var.disk_path : null
   iact_subnets                = join(",", var.iact_subnet_list)
   iact_time_limit             = var.iact_subnet_time_limit
-  operational_mode            = local.active_active ? "active-active" : var.production_type
+  operational_mode            = var.production_type
   run_pipeline_image          = var.run_pipeline_image
   tfe_image                   = var.tfe_image
   tfe_license                 = var.hc_license
@@ -342,7 +342,7 @@ module "load_balancer" {
   zones                = var.zones
 
   # General
-  active_active            = local.active_active
+  active_active            = var.production_type == "active-active"
   domain_name              = var.domain_name
   is_replicated_deployment = var.is_replicated_deployment
   tfe_subdomain            = var.tfe_subdomain

--- a/outputs.tf
+++ b/outputs.tf
@@ -92,17 +92,17 @@ output "tfe_console_password" {
 # Redis
 # -----
 output "redis_hostname" {
-  value       = var.production_type == "active-active" ? module.redis[0].redis_cache.hostname : null
+  value       = var.operational_mode == "active-active" ? module.redis[0].redis_cache.hostname : null
   description = "The Hostname of the Redis Instance"
 }
 
 output "redis_ssl_port" {
-  value       = var.production_type == "active-active" ? module.redis[0].redis_cache.ssl_port : null
+  value       = var.operational_mode == "active-active" ? module.redis[0].redis_cache.ssl_port : null
   description = "The SSL Port of the Redis Instance"
 }
 
 output "redis_pass" {
-  value       = var.production_type == "active-active" ? module.redis[0].redis_cache.primary_access_key : null
+  value       = var.operational_mode == "active-active" ? module.redis[0].redis_cache.primary_access_key : null
   description = "The Primary Access Key for the Redis Instance"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -92,17 +92,17 @@ output "tfe_console_password" {
 # Redis
 # -----
 output "redis_hostname" {
-  value       = local.active_active == true ? module.redis[0].redis_cache.hostname : null
+  value       = var.production_type == "active-active" ? module.redis[0].redis_cache.hostname : null
   description = "The Hostname of the Redis Instance"
 }
 
 output "redis_ssl_port" {
-  value       = local.active_active == true ? module.redis[0].redis_cache.ssl_port : null
+  value       = var.production_type == "active-active" ? module.redis[0].redis_cache.ssl_port : null
   description = "The SSL Port of the Redis Instance"
 }
 
 output "redis_pass" {
-  value       = local.active_active == true ? module.redis[0].redis_cache.primary_access_key : null
+  value       = var.production_type == "active-active" ? module.redis[0].redis_cache.primary_access_key : null
   description = "The Primary Access Key for the Redis Instance"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -913,13 +913,13 @@ variable "tls_version" {
   }
 }
 
-variable "production_type" {
+variable "operational_mode" {
   default     = null
   type        = string
   description = "Where Terraform Enterprise application data will be stored. Valid values are `external`, `disk`, `active-active` or `null`. Choose `external` when storing application data in an external object storage service and database. Choose `disk` when storing application data in a directory on the Terraform Enterprise instance itself. Chose `active-active` when deploying more than 1 node. Leave it `null` when you want Terraform Enterprise to use its own default."
 
   validation {
-    condition = contains(["external", "disk", "active-active", null], var.production_type)
+    condition = contains(["external", "disk", "active-active", null], var.operational_mode)
 
     error_message = "The production_type must be 'external', 'disk', `active-active` or omitted."
   }

--- a/variables.tf
+++ b/variables.tf
@@ -921,7 +921,7 @@ variable "operational_mode" {
   validation {
     condition = contains(["external", "disk", "active-active", null], var.operational_mode)
 
-    error_message = "The production_type must be 'external', 'disk', `active-active` or omitted."
+    error_message = "The operational_mode must be 'external', 'disk', `active-active` or omitted."
   }
 }
 


### PR DESCRIPTION
## Background

Follow up from my previous PR #249. It removes all the complicated logic around `active-active` and renames the property to `operational_mode` to be consistent with Google and AWS modules.