### PR TITLE
Fix wrong input in tests and examples - production_type for operational_mode

### DIFF
--- a/examples/active-active-proxy/main.tf
+++ b/examples/active-active-proxy/main.tf
@@ -80,7 +80,7 @@ module "active_active" {
   # Private Active / Active Scenario
   create_bastion             = false
   distribution               = "rhel"
-  production_type            = "external"
+  operational_mode           = "external"
   load_balancer_public       = false
   load_balancer_type         = "load_balancer"
   redis_rdb_backup_enabled   = true

--- a/examples/existing-network/main.tf
+++ b/examples/existing-network/main.tf
@@ -49,7 +49,7 @@ module "existing_network" {
 
   # Public Active / Active Scenario
   distribution            = "ubuntu"
-  production_type         = "external"
+  operational_mode        = "external"
   iact_subnet_list        = var.iact_subnet_list
   vm_node_count           = 2
   vm_sku                  = "Standard_D4_v3"

--- a/examples/standalone_airgap/main.tf
+++ b/examples/standalone_airgap/main.tf
@@ -28,7 +28,7 @@ module "standalone_airgap" {
   # Standalone, External Mode, Airgapped Installation Example
   distribution         = "ubuntu"
   iact_subnet_list     = var.iact_subnet_list
-  production_type      = "external"
+  operational_mode     = "external"
   load_balancer_public = true
   load_balancer_type   = "load_balancer"
   vm_node_count        = 1

--- a/examples/standalone_airgap_dev/main.tf
+++ b/examples/standalone_airgap_dev/main.tf
@@ -44,7 +44,7 @@ module "standalone_airgap_dev" {
 
   # Standalone External Scenario
   distribution         = "ubuntu"
-  production_type      = "external"
+  operational_mode     = "external"
   iact_subnet_list     = var.iact_subnet_list
   vm_node_count        = 1
   vm_sku               = "Standard_D4_v3"

--- a/examples/standalone_mounted_disk/main.tf
+++ b/examples/standalone_mounted_disk/main.tf
@@ -46,7 +46,7 @@ module "standalone_mounted_disk" {
   iact_subnet_list     = var.iact_subnet_list
   load_balancer_public = true
   load_balancer_type   = "application_gateway"
-  production_type      = "disk"
+  operational_mode     = "disk"
   vm_node_count        = 1
   vm_sku               = "Standard_D4_v3"
   vm_image_id          = "ubuntu"

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -71,7 +71,7 @@ module "private_active_active" {
   load_balancer_waf_rule_set_version = var.is_replicated_deployment ? "3.1" : "3.2"
   redis_use_password_auth            = true
   redis_use_tls                      = false
-  production_type                    = "external"
+  operational_mode                   = "external"
   vm_image_id                        = "rhel"
   vm_node_count                      = 2
   vm_sku                             = "Standard_D16as_v4"

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -72,7 +72,7 @@ module "private_tcp_active_active" {
   redis_use_tls              = true
   redis_rdb_backup_enabled   = true
   redis_rdb_backup_frequency = 60
-  production_type            = "external"
+  operational_mode           = "external"
   vm_node_count              = 2
   vm_sku                     = "Standard_D32a_v4"
   vm_image_id                = "rhel"

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -29,7 +29,7 @@ module "public_active_active" {
   iact_subnet_list        = var.iact_subnet_list
   load_balancer_public    = true
   load_balancer_type      = "application_gateway"
-  production_type         = "external"
+  operational_mode        = "external"
   redis_use_password_auth = false
   redis_use_tls           = false
   vm_node_count           = 2

--- a/tests/standalone-external/main.tf
+++ b/tests/standalone-external/main.tf
@@ -43,7 +43,7 @@ module "standalone_external" {
   iact_subnet_list     = ["0.0.0.0/0"]
   load_balancer_public = true
   load_balancer_type   = "load_balancer"
-  production_type      = "external"
+  operational_mode     = "external"
   vm_node_count        = 1
   vm_sku               = "Standard_D4_v3"
   vm_image_id          = "ubuntu"

--- a/tests/standalone-mounted-disk/main.tf
+++ b/tests/standalone-mounted-disk/main.tf
@@ -39,7 +39,7 @@ module "standalone_mounted_disk" {
 
   # Standalone Mounted Disk Mode Scenario
   distribution         = var.distribution
-  production_type      = "disk"
+  operational_mode     = "disk"
   disk_path            = "/opt/hashicorp/data"
   load_balancer_public = true
   load_balancer_type   = "load_balancer"

--- a/variables.tf
+++ b/variables.tf
@@ -914,12 +914,12 @@ variable "tls_version" {
 }
 
 variable "operational_mode" {
-  default     = null
+  default     = "disk"
   type        = string
   description = "Where Terraform Enterprise application data will be stored. Valid values are `external`, `disk`, `active-active` or `null`. Choose `external` when storing application data in an external object storage service and database. Choose `disk` when storing application data in a directory on the Terraform Enterprise instance itself. Chose `active-active` when deploying more than 1 node. Leave it `null` when you want Terraform Enterprise to use its own default."
 
   validation {
-    condition = contains(["external", "disk", "active-active", null], var.operational_mode)
+    condition = contains(["external", "disk", "active-active"], var.operational_mode)
 
     error_message = "The operational_mode must be 'external', 'disk', `active-active` or omitted."
   }


### PR DESCRIPTION
## Background

The #250 introduced a breaking change for the variables of the root module; `production_type` now was called `operational_mode`. I didn't update the tests and examples at that time, this one addresses that.