### PR TITLE
Revert "explicitly setting public network access to false"

### DIFF
--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -12,17 +12,16 @@ resource "azurerm_postgresql_flexible_server" "tfe" {
   name                = "${var.friendly_name_prefix}-pg"
   resource_group_name = var.resource_group_name
 
-  administrator_login           = var.database_user
-  administrator_password        = random_string.tfe_pg_password.result
-  public_network_access_enabled = false
-  backup_retention_days         = var.database_backup_retention_days
-  delegated_subnet_id           = var.database_subnet_id
-  private_dns_zone_id           = var.database_private_dns_zone_id
-  sku_name                      = var.database_machine_type
-  storage_mb                    = var.database_size_mb
-  tags                          = var.tags
-  version                       = var.database_version
-  zone                          = var.database_availability_zone
+  administrator_login    = var.database_user
+  administrator_password = random_string.tfe_pg_password.result
+  backup_retention_days  = var.database_backup_retention_days
+  delegated_subnet_id    = var.database_subnet_id
+  private_dns_zone_id    = var.database_private_dns_zone_id
+  sku_name               = var.database_machine_type
+  storage_mb             = var.database_size_mb
+  tags                   = var.tags
+  version                = var.database_version
+  zone                   = var.database_availability_zone
 }
 
 resource "azurerm_postgresql_flexible_server_configuration" "tfe" {


### PR DESCRIPTION
This reverts commit 443b6f83846e35e5ae91bc4f17155d6be48ac916. This change may be causing issues with the release pipeline.

## How Has This Been Tested

This change will be tested through the terraform-enterprise release testing pipeline and will be reverted if this issues are not resolved.


## This PR makes me feel

<img src="https://media0.giphy.com/media/jUwpNzg9IcyrK/giphy.gif"/>
