### PR TITLE
Chore: Upgrade default postgres database version

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -346,7 +346,7 @@ variable "database_size_mb" {
 }
 
 variable "database_version" {
-  default     = 12
+  default     = 16
   type        = number
   description = "Postgres version"
 }


### PR DESCRIPTION
## Background
Upgrade the default parameter for the postgres database version, since 12 is no longer supported for TFE. 

https://developer.hashicorp.com/terraform/enterprise/deploy/replicated/requirements/data-storage/postgres-requirements
