### PR TITLE
TF-11115, TF-11117, TF-11116] Adding object store connection string to output.

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -51,6 +51,11 @@ output "storage_account_container_name" {
   description = "The name of the container used by TFE"
 }
 
+output "storage_account_primary_blob_connection_string" {
+  value       = module.object_storage.storage_account_primary_blob_connection_string
+  description = "The connection string associated with the primary location for the storage account used by TFE"
+}
+
 # Database
 # --------
 output "database" {


### PR DESCRIPTION
## Background

-  Adding object store connection string to output so that release tests in TFE can pick this up and integrate with object store. 


