### PR TITLE
Adding redis MSI auth support

### DIFF
--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -26,6 +26,7 @@ variable "redis" {
     sku_name                      = string
     size                          = string
     use_password_auth             = bool
+    use_msi_auth                  = bool
     rdb_backup_enabled            = bool
     rdb_backup_frequency          = number
     rdb_backup_max_snapshot_count = number
@@ -53,4 +54,12 @@ variable "tags" {
   default     = {}
   type        = map(string)
   description = "Map of tags for resource"
+}
+
+variable "user_assigned_identity" {
+  nullable = true
+  type = object({
+    principal_id = string
+  })
+  description = "The user assigned identity to be used for authenticating to the Redis server."
 }

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -57,9 +57,9 @@ variable "tags" {
 }
 
 variable "user_assigned_identity" {
-  nullable = true
   type = object({
     principal_id = string
   })
+  default     = null
   description = "The user assigned identity to be used for authenticating to the Redis server."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -522,6 +522,12 @@ variable "redis_use_password_auth" {
   description = "If set to false, the Redis instance will be accessible without authentication. enable_authentication can only be set to false if a subnet_id is specified; and only works if there aren't existing instances within the subnet with enable_authentication set to true."
 }
 
+variable "redis_msi_auth_enabled" {
+  default     = false
+  type        = bool
+  description = "If true, Managed Identity authentication will be enabled for the Redis server."
+}
+
 variable "redis_rdb_backup_enabled" {
   default     = false
   type        = bool


### PR DESCRIPTION
## Background

This PR adds configuration to add redis MSI auth in TFE.
This is done by
- Adding a variable `redis_msi_auth_enabled` variable to the module.
- Enabling `active_directory_authentication_enabled` when msi auth is set.
- Adding a `azurerm_redis_cache_access_policy_assignment` in redis server with the vm's identity.

## How Has This Been Tested
- Made changes in local and deployed. TFE was up and running
- Triggered release test in this branch. [Run](https://github.com/hashicorp/terraform-enterprise/actions/runs/16773335146), [branch](https://github.com/hashicorp/terraform-enterprise/compare/main...redis_msi_release_test)

### Test Configuration

* Terraform Version: NA
* Any additional relevant variables: `redis_msi_auth_enabled`

## This PR makes me feel

![optional gif describing your feelings about this pr]()
