### PR TITLE
TF-30574: Add support for Explorer database configuration

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -7,6 +7,7 @@ locals {
   # TFE Architecture
   # ----------------
   disk_mode = var.operational_mode == "disk"
+  enable_explorer_database_module = local.disk_mode == false && var.explorer_db_name != null
 
   # Network
   # -------
@@ -64,6 +65,18 @@ locals {
 
   database = try(
     module.database[0],
+    {
+      name    = null
+      address = null
+      server = {
+        administrator_login    = null
+        administrator_password = null
+      }
+    }
+  )
+
+  explorer_database = try(
+    module.explorer_database[0],
     {
       name    = null
       address = null

--- a/locals.tf
+++ b/locals.tf
@@ -6,7 +6,7 @@
 locals {
   # TFE Architecture
   # ----------------
-  disk_mode = var.operational_mode == "disk"
+  disk_mode                       = var.operational_mode == "disk"
   enable_explorer_database_module = local.disk_mode == false && var.explorer_db_name != null
 
   # Network

--- a/main.tf
+++ b/main.tf
@@ -136,6 +136,33 @@ module "database" {
   tags = var.tags
 }
 
+# -----------------------------------------------------------------------------
+# Azure postgres explorer database
+# -----------------------------------------------------------------------------
+module "explorer_database" {
+  source = "./modules/database"
+  count  = local.enable_explorer_database_module ? 1 : 0
+
+  friendly_name_prefix = var.friendly_name_prefix
+  resource_group_name  = module.resource_groups.resource_group_name
+  location             = var.location
+
+  database_machine_type          = var.explorer_db_size
+  database_private_dns_zone_id   = local.network.database_private_dns_zone.id
+  database_size_mb               = var.database_size_mb
+  database_subnet_id             = local.network.database_subnet.id
+  database_user                  = var.explorer_db_username
+  database_extensions            = var.database_extensions
+  database_version               = var.database_version
+  database_backup_retention_days = var.database_backup_retention_days
+  database_availability_zone     = var.database_availability_zone
+
+  database_msi_auth_enabled = var.database_msi_auth_enabled
+  user_assigned_identity    = module.vm.user_assigned_identity
+
+  tags = var.tags
+}
+
 # ---------------------------------------------------------------------------------------------------------------
 # Azure user data / cloud init used to install and configure TFE on instance(s) using Flexible Deployment Options
 # ---------------------------------------------------------------------------------------------------------------
@@ -220,6 +247,12 @@ module "runtime_container_engine_config" {
 
   database_passwordless_azure_use_msi   = var.database_msi_auth_enabled
   database_passwordless_azure_client_id = module.vm.user_assigned_identity.client_id
+
+  explorer_database_name       = local.explorer_database.name
+  explorer_database_user       = var.database_msi_auth_enabled ? module.vm.user_assigned_identity.name : local.explorer_database.server.administrator_login
+  explorer_database_password   = var.database_msi_auth_enabled ? "" : local.explorer_database.server.administrator_password
+  explorer_database_host       = local.explorer_database.address
+  explorer_database_parameters = var.explorer_db_parameters
 
   storage_type = "azure"
 

--- a/variables.tf
+++ b/variables.tf
@@ -394,6 +394,32 @@ variable "pg_extra_params" {
   description = "Parameter keywords of the form param1=value1&param2=value2 to support additional options that may be necessary for your specific PostgreSQL server. Allowed values are documented on the PostgreSQL site. An additional restriction on the sslmode parameter is that only the require, verify-full, verify-ca, and disable values are allowed."
 }
 
+# Explorer Database
+# -----------------
+variable "explorer_db_name" {
+  default     = null
+  type        = string
+  description = "PostgreSQL instance name for Explorer."
+}
+
+variable "explorer_db_username" {
+  default     = "hashicorp"
+  type        = string
+  description = "PostgreSQL instance username for Explorer. No special characters."
+}
+
+variable "explorer_db_parameters" {
+  type        = string
+  description = "PostgreSQL server parameters for the connection URI for Explorer. Used to configure the PostgreSQL connection."
+  default     = "sslmode=require"
+}
+
+variable "explorer_db_size" {
+  type        = string
+  default     = "GP_Standard_D2s_v3"
+  description = "PostgreSQL instance size for Explorer."
+}
+
 # Load Balancer
 # -------------
 variable "load_balancer_type" {


### PR DESCRIPTION
## Background
This PR adds Azure Explorer Database support to the terraform-azurerm-terraform-enterprise module.

## How Has This Been Tested
Ran terraform validate to ensure proper syntax and module references

### Test Configuration
* Terraform Version: 1.5+
* Any additional relevant variables:
  - explorer_db_name = "tfe-explorer"
  - database_msi_auth_enabled = true
  - operational_mode = "external"
* Azure subscription with appropriate permissions for PostgreSQL and MSI resources

## This PR makes me feel
