### PR TITLE
Add Azure MSI authentication support for explorer database

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -252,7 +252,7 @@ module "runtime_container_engine_config" {
   explorer_database_password   = var.database_msi_auth_enabled ? "" : local.explorer_database.server.administrator_password
   explorer_database_host       = local.explorer_database.address
   explorer_database_name       = local.explorer_database.name
-  explorer_database_parameters = "sslmode=require"
+  explorer_database_parameters = var.explorer_db_parameters
 
   explorer_database_passwordless_azure_use_msi   = var.database_msi_auth_enabled
   explorer_database_passwordless_azure_client_id = module.vm.user_assigned_identity.client_id

--- a/main.tf
+++ b/main.tf
@@ -248,11 +248,14 @@ module "runtime_container_engine_config" {
   database_passwordless_azure_use_msi   = var.database_msi_auth_enabled
   database_passwordless_azure_client_id = module.vm.user_assigned_identity.client_id
 
-  explorer_database_name       = local.explorer_database.name
   explorer_database_user       = var.database_msi_auth_enabled ? module.vm.user_assigned_identity.name : local.explorer_database.server.administrator_login
   explorer_database_password   = var.database_msi_auth_enabled ? "" : local.explorer_database.server.administrator_password
   explorer_database_host       = local.explorer_database.address
-  explorer_database_parameters = var.explorer_db_parameters
+  explorer_database_name       = local.explorer_database.name
+  explorer_database_parameters = "sslmode=require"
+
+  explorer_database_passwordless_azure_use_msi   = var.database_msi_auth_enabled
+  explorer_database_passwordless_azure_client_id = module.vm.user_assigned_identity.client_id
 
   storage_type = "azure"
 


### PR DESCRIPTION
## Background
This PR adds Azure Managed Identity (MSI) authentication support for the explorer database by passing the `explorer_database_passwordless_azure_use_msi` and `explorer_database_passwordless_azure_client_id` variables to the `runtime_container_engine_config` module. Previously, only the primary database supported MSI authentication, causing the explorer database to fail authentication when `database_msi_auth_enabled = true`.

## How Has This Been Tested
Tested on Azure with TFE deployment using:
- Azure PostgreSQL Flexible Server with AD authentication enabled
- Explorer database enabled
- `database_msi_auth_enabled = true`
- User-assigned managed identity attached to VMSS

Verified that both primary and explorer databases successfully authenticate using MSI instead of password authentication.

### Test Configuration
## This PR makes me feel