### PR TITLE
Allow to configure redis public network access

### DIFF
--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -16,8 +16,9 @@ resource "azurerm_redis_cache" "tfe_redis" {
   family    = var.redis.family
   sku_name  = var.redis.sku_name
 
-  enable_non_ssl_port = var.redis.use_tls == true ? false : true
-  minimum_tls_version = var.redis.minimum_tls_version
+  public_network_access_enabled = var.redis.public_network_access_enabled == null ? true : var.redis.public_network_access_enabled
+  enable_non_ssl_port           = var.redis.use_tls == true ? false : true
+  minimum_tls_version           = var.redis.minimum_tls_version
 
   redis_configuration {
     enable_authentication                   = var.redis.use_password_auth

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -33,6 +33,7 @@ variable "redis" {
     rdb_existing_storage_account  = string
     minimum_tls_version           = string
     use_tls                       = bool
+    public_network_access_enabled = bool
   })
   description = <<-EOD
   family                          - The SKU family/pricing group to use. Valid values are "C" (for Basic/Standard SKU family) and "P" (for Premium)
@@ -46,6 +47,7 @@ variable "redis" {
   rdb_existing_storage_account    - Name of an existing Premium Storage Account for data encryption at rest. If value is null, a new, Premium storage account will be created.
   minimum_tls_version             - The minimum TLS version. "1.2" is suggested.
   use_tls                         - Redis service requires TLS.
+  public_network_access_enabled   - Whether public network access is allowed. The default is true.
   EOD
 }
 


### PR DESCRIPTION
## Background

Azure Redis Cache is by default exposed publicly. Our CNAPP solution identified this as a high risk, and we also believe it is unnecessary to expose it (regardless of enabled authentication) publicly. Therefore, I introduced a new property to make this configurable. The default remains as it is, but you can disable it.